### PR TITLE
Refactored Emitter and Effect state soa plus changes to multithreading

### DIFF
--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -8361,6 +8361,7 @@ void ControlParticleTransform3d(tfx_work_queue_t *queue, void *data) {
 		if (!(pm.flags & tfxEffectManagerFlags_unordered)) {	//Predictable
 			for (tfxU32 j = start_diff; j < tfxMin(limit_index + start_diff, tfxDataWidth); ++j) {
 				tfxU32 sprite_depth_index = bank.depth_index[index + j];
+				sprites.alignment[sprite_depth_index] = packed.a[j];
 				sprites.stretch[sprite_depth_index] = p_stretch.a[j];
 				sprites.transform_3d[sprite_depth_index].rotations.x = rotations_x.a[j];
 				sprites.transform_3d[sprite_depth_index].rotations.y = rotations_y.a[j];
@@ -8368,7 +8369,6 @@ void ControlParticleTransform3d(tfx_work_queue_t *queue, void *data) {
 				sprites.transform_3d[sprite_depth_index].position.x = position_x.a[j];
 				sprites.transform_3d[sprite_depth_index].position.y = position_y.a[j];
 				sprites.transform_3d[sprite_depth_index].position.z = position_z.a[j];
-				sprites.alignment[sprite_depth_index] = packed.a[j];
 				bank.captured_position_x[index + j] = sprites.transform_3d[sprite_depth_index].position.x;
 				bank.captured_position_y[index + j] = sprites.transform_3d[sprite_depth_index].position.y;
 				bank.captured_position_z[index + j] = sprites.transform_3d[sprite_depth_index].position.z;
@@ -8380,13 +8380,13 @@ void ControlParticleTransform3d(tfx_work_queue_t *queue, void *data) {
 		else {
 			for (tfxU32 j = start_diff; j < tfxMin(limit_index + start_diff, tfxDataWidth); ++j) {
 				sprites.stretch[running_sprite_index] = p_stretch.a[j];
+				sprites.alignment[running_sprite_index] = packed.a[j];
 				sprites.transform_3d[running_sprite_index].rotations.x = rotations_x.a[j];
 				sprites.transform_3d[running_sprite_index].rotations.y = rotations_y.a[j];
 				sprites.transform_3d[running_sprite_index].rotations.z = rotations_z.a[j];
 				sprites.transform_3d[running_sprite_index].position.x = position_x.a[j];
 				sprites.transform_3d[running_sprite_index].position.y = position_y.a[j];
 				sprites.transform_3d[running_sprite_index].position.z = position_z.a[j];
-				sprites.alignment[running_sprite_index] = packed.a[j];
 				bank.captured_position_x[index + j] = sprites.transform_3d[running_sprite_index].position.x;
 				bank.captured_position_y[index + j] = sprites.transform_3d[running_sprite_index].position.y;
 				bank.captured_position_z[index + j] = sprites.transform_3d[running_sprite_index].position.z;
@@ -8577,9 +8577,16 @@ void ControlParticlePosition2d(tfx_work_queue_t *queue, void *data) {
 			}
 		}
 		else {
-			for (tfxU32 j = start_diff; j < tfxMin(limit_index + start_diff, tfxDataWidth); ++j) {
+			if (start_diff == 0 && limit_index == tfxDataWidth) {
+				for (tfxU32 j = start_diff; j < tfxMin(limit_index + start_diff, tfxDataWidth); ++j) {
+					tfxWideStore(&sprites.stretch[running_sprite_index], p_stretch.m);
+					tfxWideStorei((tfxWideInt*)&sprites.alignment[running_sprite_index++], packed.m);
+				}
+			}
+			else {
 				sprites.stretch[running_sprite_index] = p_stretch.a[j];
-				sprites.alignment[running_sprite_index++] = packed.a[j];
+				sprites.alignment[running_sprite_index] = packed.a[j];
+				running_sprite_index += tfxDataWidth;
 			}
 		}
 		start_diff = 0;
@@ -8884,9 +8891,15 @@ void ControlParticleColor(tfx_work_queue_t *queue, void *data) {
 			}
 		}
 		else {
-			for (tfxU32 j = start_diff; j < tfxMin(limit_index + start_diff, tfxDataWidth); ++j) {
-				sprites.color[running_sprite_index].color = packed_color.a[j];
-				sprites.intensity[running_sprite_index++] = wide_intensity.a[j];
+			if (start_diff == 0 && limit_index == tfxDataWidth) {
+				tfxWideStorei((tfxWideInt*)&sprites.color[running_sprite_index].color, packed_color.m);
+				tfxWideStore(&sprites.intensity[running_sprite_index], wide_intensity.m);
+				running_sprite_index += tfxDataWidth;
+			} else {
+				for (tfxU32 j = start_diff; j < tfxMin(limit_index + start_diff, tfxDataWidth); ++j) {
+					sprites.color[running_sprite_index].color = packed_color.a[j];
+					sprites.intensity[running_sprite_index++] = wide_intensity.a[j];
+				}
 			}
 		}
 		start_diff = 0;

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -6399,10 +6399,6 @@ tfxErrorFlags LoadEffectLibraryPackage(tfx_package_t *package, tfx_library_t *li
 		if (context == tfxEndEmitter) {
 			InitialiseUninitialisedGraphs(&effect_stack.back());
 			UpdateEffectMaxLife(&effect_stack.back());
-#ifdef tfxTRACK_MEMORY
-			tfx_vector_t<tfx_effect_emitter_t> &sub_effectors = effect_stack.parent().GetEffectInfo(this)->sub_effectors;
-			memcpy(sub_effectors.name, "emitter_sub_effects\0", 20);
-#endif
 			if (effect_stack.back().property_flags & tfxEmitterPropertyFlags_image_handle_auto_center) {
 				lib->emitter_properties.image_handle[effect_stack.back().property_index] = { .5f, .5f };
 			}
@@ -6414,10 +6410,6 @@ tfxErrorFlags LoadEffectLibraryPackage(tfx_package_t *package, tfx_library_t *li
 		if (context == tfxEndEffect) {
 			ReIndexEffect(&effect_stack.back());
 			if (effect_stack.size() > 1) {
-#ifdef tfxTRACK_MEMORY
-				tfx_vector_t<tfx_effect_emitter_t> &sub_effectors = effect_stack.parent().GetEffectInfo(this)->sub_effectors;
-				memcpy(sub_effectors.name, "effect_sub_emitters\0", 20);
-#endif
 				if (effect_stack.parent().type == tfxStage && GetEffectInfo(&effect_stack.parent())->sub_effectors.size() == 0) {
 					tfxEffectPropertyFlags tmp = effect_stack.parent().property_flags;
 					if (Is3DEffect(&effect_stack.back())) {
@@ -7707,11 +7699,7 @@ void FreeParticleList(tfx_particle_manager_t *pm, tfxU32 index) {
 		pm->free_particle_lists.At(pm->emitters.path_hash[index]).push_back(pm->emitters.particles_index[index]);
 	}
 	else {
-#ifdef tfxTRACK_MEMORY
-		tfx_vector_t<tfxU32> new_indexes(tfxCONSTRUCTOR_VEC_INIT("FreeParticleBanks::new_indexes"));
-#else
 		tfx_vector_t<tfxU32> new_indexes;
-#endif
 		new_indexes.push_back(pm->emitters.particles_index[index]);
 		pm->free_particle_lists.Insert(pm->emitters.path_hash[index], new_indexes);
 	}
@@ -7952,9 +7940,10 @@ void UpdateParticleManager(tfx_particle_manager_t *pm, float elapsed_time) {
 				}
 			}
 
-			tfxCompleteAllWork(&pm->work_queue);
-			pm->age_work.clear();
 		}
+
+		tfxCompleteAllWork(&pm->work_queue);
+		pm->age_work.clear();
 	}
 
 	//Todo work queue this for each layer
@@ -9066,10 +9055,6 @@ void ToggleSpritesWithUID(tfx_particle_manager_t *pm, bool switch_on) {
 				FreeSoABuffer(&pm->sprite_buffer[1][layer]);
 			}
 
-#ifdef tfxTRACK_MEMORY
-			memcpy(sprites3d[layer].name, "ParticleManager::sprites3d\0", 27);
-#endif
-
 			if (pm->flags & tfxEffectManagerFlags_2d_and_3d) {
 				InitSpriteBufferSoA(&pm->sprite_buffer[0][layer], &pm->sprites[0][layer], tfxMax((pm->max_cpu_particles_per_layer[layer] / tfxDataWidth + 1) * tfxDataWidth, 8), tfxSpriteBufferMode_both, true);
 				if (pm->flags & tfxEffectManagerFlags_double_buffer_sprites) {
@@ -9183,11 +9168,6 @@ void InitParticleManagerForBoth(tfx_particle_manager_t *pm, tfx_library_t *lib, 
 
 	for (tfxEachLayer) {
 		pm->max_cpu_particles_per_layer[layer] = layer_max_values[layer];
-
-#ifdef tfxTRACK_MEMORY
-		memcpy(sprites2d[layer].name, "ParticleManager::sprites2d\0", 27);
-		memcpy(sprites3d[layer].name, "ParticleManager::sprites3d\0", 27);
-#endif
 
 		InitSpriteBufferSoA(&pm->sprite_buffer[0][layer], &pm->sprites[0][layer], tfxMax((layer_max_values[layer] / tfxDataWidth + 1) * tfxDataWidth, tfxDataWidth * 2), tfxSpriteBufferMode_both);
 		if (pm->flags & tfxEffectManagerFlags_double_buffer_sprites) {
@@ -12623,10 +12603,6 @@ void InitParticleManagerFor3d(tfx_particle_manager_t *pm, tfx_library_t *library
 	for (tfxEachLayer) {
 		pm->max_cpu_particles_per_layer[layer] = layer_max_values[layer];
 
-#ifdef tfxTRACK_MEMORY
-		memcpy(sprites3d[layer].name, "ParticleManager::sprites3d\0", 27);
-#endif
-
 		InitSpriteBufferSoA(&pm->sprite_buffer[0][layer], &pm->sprites[0][layer], tfxMax((layer_max_values[layer] / tfxDataWidth + 1) * tfxDataWidth, 8), tfxSpriteBufferMode_3d);
 		if (pm->flags & tfxEffectManagerFlags_double_buffer_sprites) {
 			InitSpriteBufferSoA(&pm->sprite_buffer[1][layer], &pm->sprites[1][layer], tfxMax((layer_max_values[layer] / tfxDataWidth + 1) * tfxDataWidth, 8), tfxSpriteBufferMode_3d);
@@ -12695,10 +12671,6 @@ void InitParticleManagerFor2d(tfx_particle_manager_t *pm, tfx_library_t *library
 
 	for (tfxEachLayer) {
 		pm->max_cpu_particles_per_layer[layer] = layer_max_values[layer];
-
-#ifdef tfxTRACK_MEMORY
-		memcpy(sprites2d[layer].name, "ParticleManager::sprites2d\0", 27);
-#endif
 
 		InitSpriteBufferSoA(&pm->sprite_buffer[0][layer], &pm->sprites[0][layer], tfxMax((layer_max_values[layer] / tfxDataWidth + 1) * tfxDataWidth, 8), tfxSpriteBufferMode_2d);
 		if (pm->flags & tfxEffectManagerFlags_double_buffer_sprites) {

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -10587,9 +10587,8 @@ void SpawnParticleLine2d(tfx_work_queue_t *queue, void *data) {
 	const tfx_vec3_t handle = pm.emitters.handle[emitter_index];
 	const tfxU32 particles_index = pm.emitters.particles_index[emitter_index];
 	const tfx_vec3_t &grid_points = properties.grid_points[property_index];
-	const tfx_vec2_t emitter_size = pm.emitters.emitter_size[emitter_index].xy();
-	const float grid_segment_size_x = emitter_size.x / (grid_points.x - 1);
-	const float grid_segment_size_y = emitter_size.y / (grid_points.y - 1);
+	const float emitter_size = pm.emitters.emitter_size[emitter_index].y;
+	const float grid_segment_size_y = emitter_size / (grid_points.x - 1);
 	tfx_vec3_t &grid_coords = pm.emitters.grid_coords[emitter_index];
 
 	for (int i = 0; i != entry->amount_to_spawn; ++i) {
@@ -10611,7 +10610,6 @@ void SpawnParticleLine2d(tfx_work_queue_t *queue, void *data) {
 				}
 			}
 
-			local_position_x = grid_coords.x * -grid_segment_size_x;
 			local_position_y = grid_coords.y * -grid_segment_size_y;
 
 			if (property_flags & tfxEmitterPropertyFlags_grid_spawn_clockwise) {
@@ -10624,7 +10622,7 @@ void SpawnParticleLine2d(tfx_work_queue_t *queue, void *data) {
 		}
 		else {
 			local_position_x = 0.f;
-			local_position_y = RandomRange(&random, -emitter_size.y, 0.f);
+			local_position_y = RandomRange(&random, -emitter_size, 0.f);
 
 		}
 
@@ -10657,10 +10655,8 @@ void SpawnParticleLine3d(tfx_work_queue_t *queue, void *data) {
 	const tfx_vec3_t handle = pm.emitters.handle[emitter_index];
 	const tfxU32 particles_index = pm.emitters.particles_index[emitter_index];
 	const tfx_vec3_t &grid_points = properties.grid_points[property_index];
-	const tfx_vec3_t emitter_size = pm.emitters.emitter_size[emitter_index];
-	const float grid_segment_size_x = emitter_size.x / (grid_points.x - 1);
-	const float grid_segment_size_y = emitter_size.y / (grid_points.y - 1);
-	const float grid_segment_size_z = emitter_size.z / (grid_points.z - 1);
+	const float emitter_size = pm.emitters.emitter_size[emitter_index].y;
+	const float grid_segment_size_y = emitter_size / (grid_points.x - 1);
 	tfx_vec3_t &grid_coords = pm.emitters.grid_coords[emitter_index];
 
 	for (int i = 0; i != entry->amount_to_spawn; ++i) {
@@ -10679,9 +10675,7 @@ void SpawnParticleLine3d(tfx_work_queue_t *queue, void *data) {
 
 			if (property_flags & tfxEmitterPropertyFlags_grid_spawn_random) {
 				grid_coords.y = (float)RandomRange(&random, (tfxU32)grid_points.x);
-				local_position_x = grid_coords.x * grid_segment_size_x;
 				local_position_y = grid_coords.y * grid_segment_size_y;
-				local_position_z = grid_coords.z * grid_segment_size_z;
 			}
 			else {
 
@@ -10692,9 +10686,7 @@ void SpawnParticleLine3d(tfx_work_queue_t *queue, void *data) {
 					}
 				}
 
-				local_position_x = grid_coords.x * grid_segment_size_x;
 				local_position_y = grid_coords.y * grid_segment_size_y;
-				local_position_z = grid_coords.z * grid_segment_size_z;
 
 				if (property_flags & tfxEmitterPropertyFlags_grid_spawn_clockwise) {
 					grid_coords.y++;
@@ -10706,9 +10698,7 @@ void SpawnParticleLine3d(tfx_work_queue_t *queue, void *data) {
 
 		}
 		else {
-			local_position_x = 0.f;
-			local_position_y = RandomRange(&random, 0.f, emitter_size.y);
-			local_position_z = 0.f;
+			local_position_y = RandomRange(&random, 0.f, emitter_size);
 		}
 
 		//----TForm and Emission

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -8578,15 +8578,15 @@ void ControlParticlePosition2d(tfx_work_queue_t *queue, void *data) {
 		}
 		else {
 			if (start_diff == 0 && limit_index == tfxDataWidth) {
-				for (tfxU32 j = start_diff; j < tfxMin(limit_index + start_diff, tfxDataWidth); ++j) {
-					tfxWideStore(&sprites.stretch[running_sprite_index], p_stretch.m);
-					tfxWideStorei((tfxWideInt*)&sprites.alignment[running_sprite_index++], packed.m);
-				}
+				tfxWideStore(&sprites.stretch[running_sprite_index], p_stretch.m);
+				tfxWideStorei((tfxWideInt*)&sprites.alignment[running_sprite_index++], packed.m);
+				running_sprite_index += tfxDataWidth;
 			}
 			else {
-				sprites.stretch[running_sprite_index] = p_stretch.a[j];
-				sprites.alignment[running_sprite_index] = packed.a[j];
-				running_sprite_index += tfxDataWidth;
+				for (tfxU32 j = start_diff; j < tfxMin(limit_index + start_diff, tfxDataWidth); ++j) {
+					sprites.stretch[running_sprite_index] = p_stretch.a[j];
+					sprites.alignment[running_sprite_index++] = packed.a[j];
+				}
 			}
 		}
 		start_diff = 0;

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -4751,7 +4751,7 @@ struct tfx_frame_meta_t {
 //This struct of arrays is used for both 2d and 3d sprites, but obviously the transform_3d data is either 2d or 3d depending on which effects you're using in the particle manager.
 //InitSprite3dSoA is called to initialise 3d sprites and InitSprite2dArray for 2d sprites. This is all managed internally by the particle manager. It's convenient to have both 2d and
 //3d in one struct like this as it makes it a lot easier to use the same control functions where we can.
-struct tfx_sprite_soa_t {	//3d takes 56 bytes of bandwidth, 2d takes 40 bytes of bandwidth
+struct tfx_sprite_soa_t {						//3d takes 56 bytes of bandwidth, 2d takes 40 bytes of bandwidth
 	tfxU32 *property_indexes;					//The image frame of animation index packed with alignment option flag and property_index
 	tfxU32 *captured_index;						//The index of the sprite in the previous frame so that it can be looked up and interpolated with
 	tfx_unique_sprite_id_t *uid;				//Unique particle id of the sprite, only used when recording sprite data

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -6531,7 +6531,7 @@ tfxINTERNAL void SpawnParticleMicroUpdate3d(tfx_work_queue_t *queue, void *data)
 tfxINTERNAL void SpawnParticleSpin3d(tfx_work_queue_t *queue, void *data);
 tfxINTERNAL void SpawnParticleSize3d(tfx_work_queue_t *queue, void *data);
 
-tfxINTERNAL void ControlParticles(tfx_particle_manager_t *pm, tfxU32 emitter_index, tfx_control_work_entry_t *work_entry);
+tfxINTERNAL void ControlParticles(tfx_work_queue_t *queue, void *data);
 
 tfxINTERNAL void ControlParticleAge(tfx_work_queue_t *queue, void *data);
 tfxINTERNAL void ControlParticleImageFrame(tfx_work_queue_t *queue, void *data);

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -4562,8 +4562,8 @@ struct tfx_emitter_soa_t {
 	tfxKey *path_hash;
 
 	//Spawn controls
-	float *life;
-	float *life_variation;
+	//float *life;
+	//float *life_variation;
 	float *arc_size;
 	float *arc_offset;
 	float *weight;
@@ -4950,6 +4950,7 @@ struct tfx_particle_frame_t {
 struct tfx_spawn_work_entry_t {
 	tfx_particle_manager_t *pm;
 	tfx_emitter_properties_soa_t *properties;
+	tfx_parent_spawn_controls_t *parent_spawn_controls;
 	tfxU32 emitter_index;
 	tfxU32 parent_index;
 	tfx_emission_type emission_type;

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -1416,6 +1416,7 @@ typedef __m256i tfxWideInt;
 #define tfxWideSubi _mm256_sub_epi32
 #define tfxWideMuli _mm256_mul_epi32
 #define tfxWideSqrt _mm256_sqrt_ps
+#define tfxWideMoveMask _mm256_movemask_epi8
 #define tfxWideShiftRight _mm256_srli_epi32
 #define tfxWideShiftLeft _mm256_slli_epi32
 #define tfxWideGreaterEqual(v1, v2) _mm256_cmp_ps(v1, v2, _CMP_GE_OS)
@@ -1493,6 +1494,7 @@ typedef __m128i tfxWideInt;
 #define tfxWideSubi _mm_sub_epi32
 #define tfxWideMuli _mm_mul_epu32
 #define tfxWideSqrt _mm_sqrt_ps
+#define tfxWideMoveMask _mm_movemask_epi8
 #define tfxWideShiftRight _mm_srli_epi32
 #define tfxWideShiftLeft _mm_slli_epi32
 #define tfxWideGreaterEqual(v1, v2) _mm_cmpge_ps(v1, v2)
@@ -1579,7 +1581,7 @@ tfxINTERNAL inline tfx128 tfxFloor128(const tfx128& x) {
 	//__m128i v1 = _mm_cmpeq_epi32(v0, v0);
 	//__m128i ji = _mm_srli_epi32(v1, 25);
 	//__m128 j = *(__m128*)&_mm_slli_epi32(ji, 23); //create vector 1.0f
-	//I'm not entirely sure why original code had above lines to create a vector of 1.f. It seems to me that the below works fine
+	//I'm not entirely sure why original code had above lines to create a vector of 1.f. It seems to me that the below works fine 
 	//Worth noting that we only need to floor small numbers for the noise algorithm so can get away with this function.
 	__m128 j = _mm_set1_ps(1.f); //create vector 1.0f
 	__m128i i = _mm_cvttps_epi32(x);
@@ -4750,15 +4752,15 @@ struct tfx_frame_meta_t {
 //InitSprite3dSoA is called to initialise 3d sprites and InitSprite2dArray for 2d sprites. This is all managed internally by the particle manager. It's convenient to have both 2d and
 //3d in one struct like this as it makes it a lot easier to use the same control functions where we can.
 struct tfx_sprite_soa_t {	//3d takes 56 bytes of bandwidth, 2d takes 40 bytes of bandwidth
-	tfxU32 *property_indexes;				//The image frame of animation index packed with alignment option flag and property_index
-	tfxU32 *captured_index;					//The index of the sprite in the previous frame so that it can be looked up and interpolated with
-	tfx_unique_sprite_id_t *uid;					//Unique particle id of the sprite, only used when recording sprite data
+	tfxU32 *property_indexes;					//The image frame of animation index packed with alignment option flag and property_index
+	tfxU32 *captured_index;						//The index of the sprite in the previous frame so that it can be looked up and interpolated with
+	tfx_unique_sprite_id_t *uid;				//Unique particle id of the sprite, only used when recording sprite data
 	tfx_sprite_transform3d_t *transform_3d;		//Transform data for 3d sprites
 	tfx_sprite_transform2d_t *transform_2d;		//Transform data for 2d sprites
-	tfxU32 *alignment;						//normalised alignment vector 3 floats packed into 10bits each with 2 bits left over or 2 packed 16bit floats for 2d
-	tfx_rgba8_t *color;						//The color tint of the sprite and blend factor in alpha channel
-	float *stretch;							//Multiplier for how much the particle is stretched in the shader (3d only)	
-	float *intensity;						//The multiplier for the sprite color
+	tfxU32 *alignment;							//normalised alignment vector 3 floats packed into 10bits each with 2 bits left over or 2 packed 16bit floats for 2d
+	tfx_rgba8_t *color;							//The color tint of the sprite and blend factor in alpha channel
+	float *stretch;								//Multiplier for how much the particle is stretched in the shader (3d only)	
+	float *intensity;							//The multiplier for the sprite color
 };
 
 enum tfxSpriteBufferMode {


### PR DESCRIPTION
Emitter and Effect state structs now use a lot less memory.
Multithreading keeps same emitters in the same threads for better caching. Works out faster then scattering spawn/control jobs without keeping emitter work together. 