### PR TITLE
Refactor of instance buffering + more

### DIFF
--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -11847,7 +11847,7 @@ void UpdateParticleManager(tfx_particle_manager_t *pm, float elapsed_time) {
 					memset(instance_data.cumulative_index_point, 0, sizeof(tfxU32) * tfxLAYERS);
 				}
 				instance_data.instance_start_index = last_instance_count;
-				last_instance_count = instance_data.instance_start_index;
+				last_instance_count += instance_data.instance_count;
 			}
 		}
 	}
@@ -14131,7 +14131,7 @@ void ControlParticleColor(tfx_work_queue_t *queue, void *data) {
 		if (pm.flags & tfxParticleManagerFlags_3d_effects) { //Predictable
 			tfx_billboard_instance_t *sprites = tfxCastBuffer(tfx_billboard_instance_t, work_entry->sprite_instances);
 			if (is_ordered) {
-				WriteParticleColorSpriteDataOrdered(sprites, pm, work_entry->layer, start_diff, limit_index, bank.depth_index, index, packed_intensity_life, curved_alpha, running_sprite_index, work_entry->effect_instance_offset);
+				WriteParticleColorSpriteDataOrdered(sprites, pm, work_entry->layer, start_diff, limit_index, bank.depth_index, index, packed_intensity_life, curved_alpha, running_sprite_index, work_entry->effect_instance_offset + work_entry->cumulative_index_point);
 			}
 			else {
 				WriteParticleColorSpriteData(sprites, start_diff, limit_index,bank.depth_index, index, packed_intensity_life, curved_alpha, running_sprite_index);
@@ -14140,7 +14140,7 @@ void ControlParticleColor(tfx_work_queue_t *queue, void *data) {
 		else {
 			tfx_sprite_instance_t *sprites = tfxCastBuffer(tfx_sprite_instance_t, work_entry->sprite_instances);
 			if (is_ordered) {
-				WriteParticleColorSpriteDataOrdered(sprites, pm, work_entry->layer, start_diff, limit_index, bank.depth_index, index, packed_intensity_life, curved_alpha, running_sprite_index, work_entry->effect_instance_offset);
+				WriteParticleColorSpriteDataOrdered(sprites, pm, work_entry->layer, start_diff, limit_index, bank.depth_index, index, packed_intensity_life, curved_alpha, running_sprite_index, work_entry->effect_instance_offset + work_entry->cumulative_index_point);
 			}
 			else {
 				WriteParticleColorSpriteData(sprites, start_diff, limit_index, bank.depth_index, index, packed_intensity_life, curved_alpha, running_sprite_index);
@@ -14219,16 +14219,14 @@ void ControlParticleImageFrame(tfx_work_queue_t *queue, void *data) {
 		if (pm.flags & tfxParticleManagerFlags_3d_effects) { //Predictable
 			tfx_billboard_instance_t *sprites = tfxCastBuffer(tfx_billboard_instance_t, work_entry->sprite_instances);
 			if (is_ordered) {
-				WriteParticleImageSpriteDataOrdered(sprites, pm, layer, start_diff, limit_index, bank, flags, image_indexes, emitter_flags, billboard_option, index, running_sprite_index, work_entry->effect_instance_offset);
-			}
-			else {
+				WriteParticleImageSpriteDataOrdered(sprites, pm, layer, start_diff, limit_index, bank, flags, image_indexes, emitter_flags, billboard_option, index, running_sprite_index, work_entry->effect_instance_offset + work_entry->cumulative_index_point);
+			} else {
 				WriteParticleImageSpriteData(sprites, pm, layer, start_diff, limit_index, bank, flags, image_indexes, emitter_flags, billboard_option, index, running_sprite_index);
 			}
-		}
-		else {
+		} else {
 			tfx_sprite_instance_t *sprites = tfxCastBuffer(tfx_sprite_instance_t, work_entry->sprite_instances);
 			if (is_ordered) {
-				WriteParticleImageSpriteDataOrdered(sprites, pm, layer, start_diff, limit_index, bank, flags, image_indexes, emitter_flags, billboard_option, index, running_sprite_index, work_entry->effect_instance_offset);
+				WriteParticleImageSpriteDataOrdered(sprites, pm, layer, start_diff, limit_index, bank, flags, image_indexes, emitter_flags, billboard_option, index, running_sprite_index, work_entry->effect_instance_offset + work_entry->cumulative_index_point);
 			} else {
 				WriteParticleImageSpriteData(sprites, pm, layer, start_diff, limit_index, bank, flags, image_indexes, emitter_flags, billboard_option, index, running_sprite_index);
 			}
@@ -15024,7 +15022,6 @@ void UpdatePMEmitter(tfx_work_queue_t *work_queue, void *data) {
 	tfxU32 &effect_instance_index_point = instance_data.sprite_index_point[layer];
 	tfxU32 &pm_instance_index_point =  pm->sprite_index_point[layer];
 	tfxU32 &instance_index_point = (pm->flags & tfxParticleManagerFlags_use_effect_sprite_buffers) ? instance_data.sprite_index_point[layer] : pm->sprite_index_point[layer];
-	instance_data.instance_start_index = tfx__Min(pm_instance_index_point, instance_data.instance_start_index);
 	if (ordered_effect) {
 		spawn_work_entry->depth_indexes = &instance_data.depth_indexes[layer][instance_data.current_depth_buffer_index[layer]];
 	}

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -3633,7 +3633,7 @@ void InitialiseUninitialisedGraphs(tfx_effect_emitter_t *effect) {
 		if (library->emitter_attributes[emitter_attributes].overtime.green_hint.nodes.size() == 0) ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.green_hint, 1.f, tfxColorPreset);
 		if (library->emitter_attributes[emitter_attributes].overtime.blue_hint.nodes.size() == 0) ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.blue_hint, 1.f, tfxColorPreset);
 		if (library->emitter_attributes[emitter_attributes].overtime.blendfactor_hint.nodes.size() == 0) ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.blendfactor_hint, 1.f, tfxOpacityOvertimePreset);
-		if (library->emitter_attributes[emitter_attributes].overtime.alpha_sharpness.nodes.size() == 0) ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.alpha_sharpness, 1.f, tfxOpacityOvertimePreset);
+		if (library->emitter_attributes[emitter_attributes].overtime.alpha_sharpness.nodes.size() == 0) ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.alpha_sharpness, 0.f, tfxOpacityOvertimePreset);
 		if (library->emitter_attributes[emitter_attributes].overtime.curved_alpha.nodes.size() == 0) ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.curved_alpha, 1.f, tfxOpacityOvertimePreset);
 		if (library->emitter_attributes[emitter_attributes].overtime.velocity_turbulance.nodes.size() == 0) ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.velocity_turbulance, 0.f, tfxFrameratePreset);
 		if (library->emitter_attributes[emitter_attributes].overtime.direction_turbulance.nodes.size() == 0) ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.direction_turbulance, 0.f, tfxPercentOvertime);

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -11585,7 +11585,7 @@ void UpdateEmitterControlProfile(tfx_effect_emitter_t *emitter) {
 	if (props->emission_type == tfxPath) {
 		emitter->control_profile |= tfxEmitterControlProfile_path;
 	}
-	if (emitter->property_flags & tfxEmitterPropertyFlags_edge_traversal) {
+	if (emitter->property_flags & tfxEmitterPropertyFlags_edge_traversal && (props->emission_type == tfxPath || props->emission_type == tfxLine)) {
 		emitter->control_profile |= tfxEmitterControlProfile_edge_traversal;
 		if (props->end_behaviour == tfxLoop) {
 			emitter->control_profile |= tfxEmitterControlProfile_edge_loop;

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -297,11 +297,11 @@ namespace tfx {
 		tfx128Array gi0x, gi0y, gi0z, gi1x, gi1y, gi1z, gi2x, gi2y, gi2z, gi3x, gi3y, gi3z;
 
 		tfxNoise3dGradientLoopUnroll(0)
-			tfxNoise3dGradientLoopUnroll(1)
-			tfxNoise3dGradientLoopUnroll(2)
-			tfxNoise3dGradientLoopUnroll(3)
+		tfxNoise3dGradientLoopUnroll(1)
+		tfxNoise3dGradientLoopUnroll(2)
+		tfxNoise3dGradientLoopUnroll(3)
 
-			tfx128 n0 = _mm_mul_ps(t0q, Dot128XYZ(&gi0x.m, &gi0y.m, &gi0z.m, &x0, &y0, &z0));
+		tfx128 n0 = _mm_mul_ps(t0q, Dot128XYZ(&gi0x.m, &gi0y.m, &gi0z.m, &x0, &y0, &z0));
 		tfx128 n1 = _mm_mul_ps(t1q, Dot128XYZ(&gi1x.m, &gi1y.m, &gi1z.m, &x1, &y1, &z1));
 		tfx128 n2 = _mm_mul_ps(t2q, Dot128XYZ(&gi2x.m, &gi2y.m, &gi2z.m, &x2, &y2, &z2));
 		tfx128 n3 = _mm_mul_ps(t3q, Dot128XYZ(&gi3x.m, &gi3y.m, &gi3z.m, &x3, &y3, &z3));

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -2885,8 +2885,8 @@ void UpdateEffectMaxLife(tfx_effect_emitter_t *effect) {
 	GetEffectGraphByType(effect, tfxOvertime_blue)->lookup.life = info->max_life;
 	GetEffectGraphByType(effect, tfxOvertime_blendfactor)->lookup.life = info->max_life;
 	GetEffectGraphByType(effect, tfxOvertime_intensity)->lookup.life = info->max_life;
-	GetEffectGraphByType(effect, tfxOvertime_hint_intensity)->lookup.life = info->max_life;
-	GetEffectGraphByType(effect, tfxOvertime_color_mix_balance)->lookup.life = info->max_life;
+	GetEffectGraphByType(effect, tfxOvertime_alpha_sharpness)->lookup.life = info->max_life;
+	GetEffectGraphByType(effect, tfxOvertime_curved_alpha)->lookup.life = info->max_life;
 	GetEffectGraphByType(effect, tfxOvertime_velocity)->lookup.life = info->max_life;
 	GetEffectGraphByType(effect, tfxOvertime_width)->lookup.life = info->max_life;
 	GetEffectGraphByType(effect, tfxOvertime_height)->lookup.life = info->max_life;
@@ -3514,8 +3514,8 @@ void ResetEmitterOvertimeGraphs(tfx_effect_emitter_t *effect, bool add_node, boo
 	ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.green_hint, 1.f, tfxColorPreset, add_node); library->emitter_attributes[emitter_attributes].overtime.green_hint.type = tfxOvertime_green_hint;
 	ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.blue_hint, 1.f, tfxColorPreset, add_node); library->emitter_attributes[emitter_attributes].overtime.blue_hint.type = tfxOvertime_blue_hint;
 	ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.blendfactor_hint, 1.f, tfxOpacityOvertimePreset, add_node); library->emitter_attributes[emitter_attributes].overtime.blendfactor_hint.type = tfxOvertime_blendfactor_hint;
-	ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.hint_intensity, 1.f, tfxIntensityOvertimePreset, add_node); library->emitter_attributes[emitter_attributes].overtime.hint_intensity.type = tfxOvertime_hint_intensity;
-	ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.color_mix_balance, 1.f, tfxOpacityOvertimePreset, add_node); library->emitter_attributes[emitter_attributes].overtime.color_mix_balance.type = tfxOvertime_color_mix_balance;
+	ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.alpha_sharpness, 1.f, tfxOpacityOvertimePreset, add_node); library->emitter_attributes[emitter_attributes].overtime.alpha_sharpness.type = tfxOvertime_alpha_sharpness;
+	ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.curved_alpha, 1.f, tfxOpacityOvertimePreset, add_node); library->emitter_attributes[emitter_attributes].overtime.curved_alpha.type = tfxOvertime_curved_alpha;
 	ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.velocity_turbulance, 30.f, tfxVelocityTurbulancePreset, add_node); library->emitter_attributes[emitter_attributes].overtime.velocity_turbulance.type = tfxOvertime_velocity_turbulance;
 	ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.stretch, 0.f, tfxPercentOvertime, add_node); library->emitter_attributes[emitter_attributes].overtime.stretch.type = tfxOvertime_stretch;
 	ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.direction_turbulance, 0.f, tfxPercentOvertime, add_node); library->emitter_attributes[emitter_attributes].overtime.direction_turbulance.type = tfxOvertime_direction_turbulance;
@@ -3633,8 +3633,8 @@ void InitialiseUninitialisedGraphs(tfx_effect_emitter_t *effect) {
 		if (library->emitter_attributes[emitter_attributes].overtime.green_hint.nodes.size() == 0) ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.green_hint, 1.f, tfxColorPreset);
 		if (library->emitter_attributes[emitter_attributes].overtime.blue_hint.nodes.size() == 0) ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.blue_hint, 1.f, tfxColorPreset);
 		if (library->emitter_attributes[emitter_attributes].overtime.blendfactor_hint.nodes.size() == 0) ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.blendfactor_hint, 1.f, tfxOpacityOvertimePreset);
-		if (library->emitter_attributes[emitter_attributes].overtime.hint_intensity.nodes.size() == 0) ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.hint_intensity, 1.f, tfxIntensityOvertimePreset);
-		if (library->emitter_attributes[emitter_attributes].overtime.color_mix_balance.nodes.size() == 0) ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.color_mix_balance, 1.f, tfxOpacityOvertimePreset);
+		if (library->emitter_attributes[emitter_attributes].overtime.alpha_sharpness.nodes.size() == 0) ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.alpha_sharpness, 1.f, tfxOpacityOvertimePreset);
+		if (library->emitter_attributes[emitter_attributes].overtime.curved_alpha.nodes.size() == 0) ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.curved_alpha, 1.f, tfxOpacityOvertimePreset);
 		if (library->emitter_attributes[emitter_attributes].overtime.velocity_turbulance.nodes.size() == 0) ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.velocity_turbulance, 0.f, tfxFrameratePreset);
 		if (library->emitter_attributes[emitter_attributes].overtime.direction_turbulance.nodes.size() == 0) ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.direction_turbulance, 0.f, tfxPercentOvertime);
 		if (library->emitter_attributes[emitter_attributes].overtime.velocity_adjuster.nodes.size() == 0) ResetGraph(&library->emitter_attributes[emitter_attributes].overtime.velocity_adjuster, 1.f, tfxGlobalPercentPreset);
@@ -5068,8 +5068,8 @@ void InitialiseOvertimeAttributes(tfx_overtime_attributes_t *attributes, tfxU32 
 	attributes->direction_turbulance.nodes = tfxCreateBucketArray<tfx_attribute_node_t>(bucket_size);
 	attributes->velocity_adjuster.nodes = tfxCreateBucketArray<tfx_attribute_node_t>(bucket_size);
 	attributes->intensity.nodes = tfxCreateBucketArray<tfx_attribute_node_t>(bucket_size);
-	attributes->hint_intensity.nodes = tfxCreateBucketArray<tfx_attribute_node_t>(bucket_size);
-	attributes->color_mix_balance.nodes = tfxCreateBucketArray<tfx_attribute_node_t>(bucket_size);
+	attributes->alpha_sharpness.nodes = tfxCreateBucketArray<tfx_attribute_node_t>(bucket_size);
+	attributes->curved_alpha.nodes = tfxCreateBucketArray<tfx_attribute_node_t>(bucket_size);
 	attributes->direction.nodes = tfxCreateBucketArray<tfx_attribute_node_t>(bucket_size);
 	attributes->noise_resolution.nodes = tfxCreateBucketArray<tfx_attribute_node_t>(bucket_size);
 	attributes->motion_randomness.nodes = tfxCreateBucketArray<tfx_attribute_node_t>(bucket_size);
@@ -5103,8 +5103,8 @@ void FreeOvertimeAttributes(tfx_overtime_attributes_t *attributes) {
 	FreeGraph(&attributes->direction_turbulance);
 	FreeGraph(&attributes->velocity_adjuster);
 	FreeGraph(&attributes->intensity);
-	FreeGraph(&attributes->hint_intensity);
-	FreeGraph(&attributes->color_mix_balance);
+	FreeGraph(&attributes->alpha_sharpness);
+	FreeGraph(&attributes->curved_alpha);
 	FreeGraph(&attributes->direction);
 	FreeGraph(&attributes->noise_resolution);
 	FreeGraph(&attributes->motion_randomness);
@@ -5134,8 +5134,8 @@ void CopyOvertimeAttributesNoLookups(tfx_overtime_attributes_t *src, tfx_overtim
 	CopyGraphNoLookups(&src->direction_turbulance, &dst->direction_turbulance);
 	CopyGraphNoLookups(&src->velocity_adjuster, &dst->velocity_adjuster);
 	CopyGraphNoLookups(&src->intensity, &dst->intensity);
-	CopyGraphNoLookups(&src->hint_intensity, &dst->hint_intensity);
-	CopyGraphNoLookups(&src->color_mix_balance, &dst->color_mix_balance);
+	CopyGraphNoLookups(&src->alpha_sharpness, &dst->alpha_sharpness);
+	CopyGraphNoLookups(&src->curved_alpha, &dst->curved_alpha);
 	CopyGraphNoLookups(&src->direction, &dst->direction);
 	CopyGraphNoLookups(&src->noise_resolution, &dst->noise_resolution);
 	CopyGraphNoLookups(&src->motion_randomness, &dst->motion_randomness);
@@ -5161,8 +5161,8 @@ void CopyOvertimeAttributes(tfx_overtime_attributes_t *src, tfx_overtime_attribu
 	CopyGraph(&src->direction_turbulance, &dst->direction_turbulance);
 	CopyGraph(&src->velocity_adjuster, &dst->velocity_adjuster);
 	CopyGraph(&src->intensity, &dst->intensity);
-	CopyGraph(&src->hint_intensity, &dst->hint_intensity);
-	CopyGraph(&src->color_mix_balance, &dst->color_mix_balance);
+	CopyGraph(&src->alpha_sharpness, &dst->alpha_sharpness);
+	CopyGraph(&src->curved_alpha, &dst->curved_alpha);
 	CopyGraph(&src->direction, &dst->direction);
 	CopyGraph(&src->noise_resolution, &dst->noise_resolution);
 	CopyGraph(&src->motion_randomness, &dst->motion_randomness);
@@ -6338,8 +6338,8 @@ void CompileAllLibraryGraphs(tfx_library_t *library) {
 
 		CompileGraphOvertime(&g.overtime.blendfactor);
 		CompileGraphOvertime(&g.overtime.intensity);
-		CompileGraphOvertime(&g.overtime.hint_intensity);
-		CompileGraphOvertime(&g.overtime.color_mix_balance);
+		CompileGraphOvertime(&g.overtime.alpha_sharpness);
+		CompileGraphOvertime(&g.overtime.curved_alpha);
 		CompileGraphOvertime(&g.overtime.velocity_turbulance);
 		CompileGraphOvertime(&g.overtime.width);
 		CompileGraphOvertime(&g.overtime.height);
@@ -6456,8 +6456,8 @@ void CompileLibraryOvertimeGraph(tfx_library_t *library, tfxU32 index) {
 	EditColorRampBitmap(library, &g, 0);
 	EditColorRampBitmap(library, &g, 1);
 	CompileGraphOvertime(&g.intensity);
-	CompileGraphOvertime(&g.hint_intensity);
-	CompileGraphOvertime(&g.color_mix_balance);
+	CompileGraphOvertime(&g.alpha_sharpness);
+	CompileGraphOvertime(&g.curved_alpha);
 	CompileGraphOvertime(&g.velocity_turbulance);
 	CompileGraphOvertime(&g.width);
 	CompileGraphOvertime(&g.height);
@@ -6569,8 +6569,8 @@ void SetLibraryMinMaxData(tfx_library_t *library) {
 	library->graph_min_max[tfxOvertime_green_hint] = GetMinMaxGraphValues(tfxColorPreset);
 	library->graph_min_max[tfxOvertime_blue_hint] = GetMinMaxGraphValues(tfxColorPreset);
 	library->graph_min_max[tfxOvertime_blendfactor_hint] = GetMinMaxGraphValues(tfxOpacityOvertimePreset);
-	library->graph_min_max[tfxOvertime_hint_intensity] = GetMinMaxGraphValues(tfxIntensityOvertimePreset);
-	library->graph_min_max[tfxOvertime_color_mix_balance] = GetMinMaxGraphValues(tfxOpacityOvertimePreset);
+	library->graph_min_max[tfxOvertime_alpha_sharpness] = GetMinMaxGraphValues(tfxIntensityOvertimePreset);
+	library->graph_min_max[tfxOvertime_curved_alpha] = GetMinMaxGraphValues(tfxOpacityOvertimePreset);
 	library->graph_min_max[tfxOvertime_velocity_turbulance] = GetMinMaxGraphValues(tfxFrameratePreset);
 	library->graph_min_max[tfxOvertime_direction_turbulance] = GetMinMaxGraphValues(tfxPercentOvertime);
 	library->graph_min_max[tfxOvertime_velocity_adjuster] = GetMinMaxGraphValues(tfxGlobalPercentPreset);
@@ -6810,8 +6810,8 @@ void tfx_data_types_dictionary_t::Init() {
 	names_and_types.Insert("overtime_green_hint", tfxFloat);
 	names_and_types.Insert("overtime_blue_hint", tfxFloat);
 	names_and_types.Insert("overtime_blendfactor_hint", tfxFloat);
-	names_and_types.Insert("overtime_hint_intensity", tfxFloat);
-	names_and_types.Insert("overtime_color_mix_balance", tfxFloat);
+	names_and_types.Insert("overtime_alpha_sharpness", tfxFloat);
+	names_and_types.Insert("overtime_curved_alpha", tfxFloat);
 	names_and_types.Insert("overtime_velocity_turbulance", tfxFloat);
 	names_and_types.Insert("overtime_direction_turbulance", tfxFloat);
 	names_and_types.Insert("overtime_velocity_adjuster", tfxFloat);
@@ -7057,8 +7057,10 @@ void AssignGraphData(tfx_effect_emitter_t *effect, tfx_vector_t<tfx_str256_t> *v
 		if ((*values)[0] == "overtime_green_hint") { tfx_attribute_node_t n; AssignNodeData(&n, values); AddGraphNode(&effect->library->emitter_attributes[effect->emitter_attributes].overtime.green_hint, &n); }
 		if ((*values)[0] == "overtime_blue_hint") { tfx_attribute_node_t n; AssignNodeData(&n, values); AddGraphNode(&effect->library->emitter_attributes[effect->emitter_attributes].overtime.blue_hint, &n); }
 		if ((*values)[0] == "overtime_blendfactor_hint") { tfx_attribute_node_t n; AssignNodeData(&n, values); AddGraphNode(&effect->library->emitter_attributes[effect->emitter_attributes].overtime.blendfactor_hint, &n); }
-		if ((*values)[0] == "overtime_intensity_hint") { tfx_attribute_node_t n; AssignNodeData(&n, values); AddGraphNode(&effect->library->emitter_attributes[effect->emitter_attributes].overtime.hint_intensity, &n); }
-		if ((*values)[0] == "overtime_color_mix_balance") { tfx_attribute_node_t n; AssignNodeData(&n, values); AddGraphNode(&effect->library->emitter_attributes[effect->emitter_attributes].overtime.color_mix_balance, &n); }
+		if ((*values)[0] == "overtime_alpha_sharpness") { tfx_attribute_node_t n; AssignNodeData(&n, values); AddGraphNode(&effect->library->emitter_attributes[effect->emitter_attributes].overtime.alpha_sharpness, &n); }
+		if ((*values)[0] == "overtime_curved_alpha") { tfx_attribute_node_t n; AssignNodeData(&n, values); AddGraphNode(&effect->library->emitter_attributes[effect->emitter_attributes].overtime.curved_alpha, &n); }
+		if ((*values)[0] == "overtime_intensity_hint") { tfx_attribute_node_t n; AssignNodeData(&n, values); AddGraphNode(&effect->library->emitter_attributes[effect->emitter_attributes].overtime.alpha_sharpness, &n); }
+		if ((*values)[0] == "overtime_color_mix_balance") { tfx_attribute_node_t n; AssignNodeData(&n, values); AddGraphNode(&effect->library->emitter_attributes[effect->emitter_attributes].overtime.curved_alpha, &n); }
 		if ((*values)[0] == "overtime_velocity_turbulance") { tfx_attribute_node_t n; AssignNodeData(&n, values); AddGraphNode(&effect->library->emitter_attributes[effect->emitter_attributes].overtime.velocity_turbulance, &n); }
 		if ((*values)[0] == "overtime_spin") { tfx_attribute_node_t n; AssignNodeData(&n, values); AddGraphNode(&effect->library->emitter_attributes[effect->emitter_attributes].overtime.spin, &n); }
 		if ((*values)[0] == "overtime_roll_spin") { tfx_attribute_node_t n; AssignNodeData(&n, values); AddGraphNode(&effect->library->emitter_attributes[effect->emitter_attributes].overtime.spin, &n); }
@@ -8947,7 +8949,7 @@ void CompileGraph(tfx_graph_t *graph) {
 }
 
 void CompileGraphOvertime(tfx_graph_t *graph) {
-	if (graph->type == tfxOvertime_intensity || graph->type == tfxOvertime_color_mix_balance || graph->type == tfxOvertime_hint_intensity) {
+	if (graph->type == tfxOvertime_intensity || graph->type == tfxOvertime_curved_alpha || graph->type == tfxOvertime_alpha_sharpness) {
 		CompileGraphRampOvertime(graph);
 		return;
 	}
@@ -14145,8 +14147,8 @@ void ControlParticleColor(tfx_work_queue_t *queue, void *data) {
 		}
 		ramp_index.m = tfxWideMini(tfxWideConverti(tfxWideMul(life, color_ramp_size)), color_ramp_sizei);
 		tfxWideFloat lookup_intensity = tfxWideLookupSet(work_entry->graphs->intensity.lookup.values, ramp_index);
-		tfxWideFloat dissolve_lerp = tfxWideLookupSet(work_entry->graphs->color_mix_balance.lookup.values, ramp_index);
-		tfxWideFloat sharpness = tfxWideLookupSet(work_entry->graphs->hint_intensity.lookup.values, ramp_index);
+		tfxWideFloat dissolve_lerp = tfxWideLookupSet(work_entry->graphs->curved_alpha.lookup.values, ramp_index);
+		tfxWideFloat sharpness = tfxWideLookupSet(work_entry->graphs->alpha_sharpness.lookup.values, ramp_index);
 
 		//----Color changes
 		lookup_intensity = tfxWideMul(tfxWideMul(global_intensity, lookup_intensity), intensity_factor);

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -3881,7 +3881,7 @@ void CloneEffect(tfx_effect_emitter_t *effect_to_clone, tfx_effect_emitter_t *cl
 			CompileLibraryPropertyGraph(clone->library, clone->emitter_attributes);
 			CompileLibraryBaseGraph(clone->library, clone->emitter_attributes);
 			CompileLibraryVariationGraph(clone->library, clone->emitter_attributes);
-			CompileLibraryOvertimeGraph(clone->library, clone->emitter_attributes);
+			CompileLibraryOvertimeGraph(clone->library, clone->emitter_attributes, false);
 			CompileLibraryFactorGraph(clone->library, clone->emitter_attributes);
 		}
 		if (clone->path_attributes != tfxINVALID) {
@@ -5139,6 +5139,8 @@ void CopyOvertimeAttributesNoLookups(tfx_overtime_attributes_t *src, tfx_overtim
 	CopyGraphNoLookups(&src->direction, &dst->direction);
 	CopyGraphNoLookups(&src->noise_resolution, &dst->noise_resolution);
 	CopyGraphNoLookups(&src->motion_randomness, &dst->motion_randomness);
+	dst->color_ramps[0] = src->color_ramps[0];
+	dst->color_ramps[1] = src->color_ramps[1];
 	dst->color_ramp_bitmap_indexes[0] = src->color_ramp_bitmap_indexes[0];
 	dst->color_ramp_bitmap_indexes[1] = src->color_ramp_bitmap_indexes[1];
 	tfxUnFlagColorRampIDAsEdited(dst->color_ramp_bitmap_indexes[0]);
@@ -6449,17 +6451,17 @@ void CompileLibraryVariationGraph(tfx_library_t *library, tfxU32 index) {
 	CompileGraph(&g.weight);
 }
 
-void CompileLibraryOvertimeGraph(tfx_library_t *library, tfxU32 index, bool including_color_graphs) {
+void CompileLibraryOvertimeGraph(tfx_library_t *library, tfxU32 index, bool including_color_ramps) {
 	tfx_overtime_attributes_t &g = library->emitter_attributes[index].overtime;
-	if (including_color_graphs) {
+	if (including_color_ramps) {
 		g.color_ramps[0] = CompileColorRamp(&g);
 		g.color_ramps[1] = CompileColorRampHint(&g);
 		EditColorRampBitmap(library, &g, 0);
 		EditColorRampBitmap(library, &g, 1);
-		CompileGraphOvertime(&g.intensity);
-		CompileGraphOvertime(&g.alpha_sharpness);
-		CompileGraphOvertime(&g.curved_alpha);
 	}
+	CompileGraphOvertime(&g.intensity);
+	CompileGraphOvertime(&g.alpha_sharpness);
+	CompileGraphOvertime(&g.curved_alpha);
 	CompileGraphOvertime(&g.velocity_turbulance);
 	CompileGraphOvertime(&g.width);
 	CompileGraphOvertime(&g.height);

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -18708,6 +18708,10 @@ bool GetNextBillboardBuffer(tfx_particle_manager_t *pm, tfx_billboard_instance_t
 	return true;
 }
 
+bool ResetInstanceBufferLoopIndex(tfx_particle_manager_t *pm) {
+	pm->effect_index_position = 0;
+}
+
 void SetEffectRotation(tfx_particle_manager_t *pm, tfxEffectID effect_index, float rotation) {
 	TFX_ASSERT(ValidEffectID(pm, effect_index));    //Not a valid effect id. Make sure that when you call AddEffectToParticleManager you check that it returns true.
 	pm->effects[effect_index].local_rotations.roll = rotation;

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -10683,14 +10683,6 @@ void RecordSpriteData(tfx_particle_manager_t *pm, tfx_effect_emitter_t *effect, 
 
 	}
 
-	tfxU32 running_offset = 0;
-	for (int f = 0; f != frames; ++f) {
-		//sprite_data->normal.frame_meta[f].captured_offset += running_offset;
-		for (tfxEachLayer) {
-			running_offset += sprite_data->normal.frame_meta[f].cumulative_offset[layer];
-		}
-	}
-
 	sprite_data->real_time_sprites_buffer.current_size = total_sprites;
 	//total sprites should not exceed the capacity of the sprite buffer
 	TFX_ASSERT(sprite_data->real_time_sprites_buffer.current_size <= sprite_data->real_time_sprites_buffer.capacity);

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -8499,7 +8499,7 @@ void ResetGraph(tfx_graph_t *graph, float v, tfx_graph_preset preset, bool add_n
 		graph->min = { 0.f, 0.f }; graph->max = { 1.f, 255.f };
 		break;
 	case tfx_graph_preset::tfxIntensityOvertimePreset:
-		graph->min = { 0.f, 0.f }; graph->max = { 1.f, 5.f };
+		graph->min = { 0.f, 0.f }; graph->max = { 1.f, 10.f };
 		break;
 	case tfx_graph_preset::tfxPathDirectionOvertimePreset:
 		graph->min = { 0.f, -4320.f }; graph->max = { 1.f, 4320.f };
@@ -8591,7 +8591,7 @@ tfx_vec4_t GetMinMaxGraphValues(tfx_graph_preset preset) {
 		mm = { 0.f, 0.f, 1.f, 255.f };
 		break;
 	case tfx_graph_preset::tfxIntensityOvertimePreset:
-		mm = { 0.f, 0.f, 1.f, 5.f };
+		mm = { 0.f, 0.f, 1.f, 10.f };
 		break;
 	default:
 		mm = { 0.f, 0.f, tfxMAX_FRAME, 20.f };

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -15005,6 +15005,7 @@ void UpdatePMEmitter(tfx_work_queue_t *work_queue, void *data) {
 	bool is_recording = (pm->flags & tfxParticleManagerFlags_recording_sprites) > 0 && (pm->flags & tfxParticleManagerFlags_using_uids) > 0;
 	tfx_buffer_t &instance_buffer = !is_recording ? pm->instance_buffer : pm->instance_buffer_for_recording[pm->current_sprite_buffer][layer];
 	tfxU32 &sprite_index_point = pm->sprite_index_point[layer];
+	effect_sprites.instance_start_index = tfx__Min(sprite_index_point, effect_sprites.instance_start_index);
 	if (ordered_effect) {
 		spawn_work_entry->depth_indexes = &effect_sprites.depth_indexes[layer][effect_sprites.current_depth_buffer_index[layer]];
 	}
@@ -18044,7 +18045,6 @@ void ControlParticles(tfx_work_queue_t *queue, void *data) {
 	work_entry->layer = properties.layer;
 	work_entry->sprites_index = emitter.sprites_index + work_entry->start_index + pm->cumulative_index_point[work_entry->layer];
 	tfx_effect_instance_data_t &effect_sprites = pm->effects[emitter.root_index].instance_data;
-	effect_sprites.instance_start_index = tfx__Min(work_entry->sprites_index, effect_sprites.instance_start_index);
 	work_entry->sprite_buffer_end_index = work_entry->sprites_index + (work_entry->end_index - work_entry->start_index);
 	tfx_effect_instance_data_t &sprites = pm->effects[emitter.root_index].instance_data;
 	work_entry->depth_indexes = &sprites.depth_indexes[work_entry->layer][sprites.current_depth_buffer_index[work_entry->layer]];

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -11757,6 +11757,7 @@ void UpdateParticleManager(tfx_particle_manager_t *pm, float elapsed_time) {
 
 	tfxU32 effects_start_size[tfxMAXDEPTH];
 	tfxU32 emitter_start_size[tfxMAXDEPTH];
+	memset(emitter_start_size, 0, tfxMAXDEPTH * sizeof(tfxU32));
 	for (int depth = 0; depth != tfxMAXDEPTH; ++depth) {
 		effects_start_size[depth] = pm->effects_in_use[depth][pm->current_ebuff].current_size;
 	}

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -18708,7 +18708,7 @@ bool GetNextBillboardBuffer(tfx_particle_manager_t *pm, tfx_billboard_instance_t
 	return true;
 }
 
-bool ResetInstanceBufferLoopIndex(tfx_particle_manager_t *pm) {
+void ResetInstanceBufferLoopIndex(tfx_particle_manager_t *pm) {
 	pm->effect_index_position = 0;
 }
 

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -12096,6 +12096,12 @@ void UpdateParticleManager(tfx_particle_manager_t *pm, float elapsed_time) {
 			}
 			effects_in_use[j + 1] = key;
 		}
+		tfxU32 running_instance_offset = 0;
+		for (tfxU32 i = 0; i != effects_in_use.current_size; ++i) {
+			tfx_effect_instance_data_t &instance_data = pm->effects[effects_in_use[i].index].instance_data;
+			instance_data.instance_start_index += running_instance_offset;
+			running_instance_offset += instance_data.instance_count;
+		}
 	}
 
 	if (pm->flags & tfxParticleManagerFlags_update_bounding_boxes) {

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -12112,6 +12112,7 @@ void ControlParticlePositionPath2d(tfx_work_queue_t *queue, void *data) {
 	tfx_particle_manager_t &pm = *work_entry->pm;
 	tfx_emitter_state_t &emitter = pm.emitters[emitter_index];
 	tfx_particle_soa_t &bank = work_entry->pm->particle_arrays[emitter.particles_index];
+	tfxU32 captured_offset = (pm.flags & tfxParticleManagerFlags_use_effect_sprite_buffers) ? pm.effects[emitter.root_index].instance_data.instance_start_index : 0;
 
 	//There must be a path setup for the emitter.
 	TFX_ASSERT(emitter.path_attributes != tfxINVALID);
@@ -13116,6 +13117,7 @@ void ControlParticleTransform3d(tfx_work_queue_t *queue, void *data) {
 	tfx_emitter_state_t &emitter = pm.emitters[work_entry->emitter_index];
 	tfx_bounding_box_t &bounding_box = emitter.bounding_box;
 	tfx_particle_soa_t &bank = work_entry->pm->particle_arrays[emitter.particles_index];
+	tfxU32 captured_offset = (pm.flags & tfxParticleManagerFlags_use_effect_sprite_buffers) ? pm.effects[emitter.root_index].instance_data.instance_start_index : 0;
 
 	tfxU32 running_sprite_index = work_entry->sprites_index;
 
@@ -13315,6 +13317,7 @@ void ControlParticlePosition2d(tfx_work_queue_t *queue, void *data) {
 	tfx_particle_manager_t &pm = *work_entry->pm;
 	tfx_emitter_state_t &emitter = pm.emitters[work_entry->emitter_index];
 	tfx_particle_soa_t &bank = work_entry->pm->particle_arrays[emitter.particles_index];
+	tfxU32 captured_offset = (pm.flags & tfxParticleManagerFlags_use_effect_sprite_buffers) ? pm.effects[emitter.root_index].instance_data.instance_start_index : 0;
 
 	const tfxWideFloat overal_scale_wide = tfxWideSetSingle(work_entry->overal_scale);
 
@@ -13640,6 +13643,7 @@ void ControlParticleTransform2d(tfx_work_queue_t *queue, void *data) {
 	tfx_emitter_state_t &emitter = pm.emitters[work_entry->emitter_index];
 	tfx_bounding_box_t &bounding_box = emitter.bounding_box;
 	tfx_particle_soa_t &bank = work_entry->pm->particle_arrays[emitter.particles_index];
+	tfxU32 captured_offset = (pm.flags & tfxParticleManagerFlags_use_effect_sprite_buffers) ? pm.effects[emitter.root_index].instance_data.instance_start_index : 0;
 
 	tfx_sprite_instance_t *sprites = tfxCastBuffer(tfx_sprite_instance_t, work_entry->sprite_instances);
 	tfxU32 running_sprite_index = work_entry->sprites_index;
@@ -13750,6 +13754,7 @@ void ControlParticleSpin(tfx_work_queue_t *queue, void *data) {
 	tfx_emitter_state_t &emitter = pm.emitters[work_entry->emitter_index];
 	const tfx_emission_type emission_type = work_entry->properties->emission_type;
 	tfx_particle_soa_t &bank = pm.particle_arrays[emitter.particles_index];
+	tfxU32 captured_offset = (pm.flags & tfxParticleManagerFlags_use_effect_sprite_buffers) ? pm.effects[emitter.root_index].instance_data.instance_start_index : 0;
 
 	const tfxWideInt spin_last_frame = tfxWideSetSinglei(work_entry->graphs->spin.lookup.last_frame);
 
@@ -13819,7 +13824,7 @@ void ControlParticleSpin(tfx_work_queue_t *queue, void *data) {
 		else {
 			if (is_ordered) {        //Predictable
 				for (tfxU32 j = start_diff; j < tfxMin(limit_index + start_diff, tfxDataWidth); ++j) {
-					tfxU32 sprite_depth_index = bank.depth_index[index + j] + pm.cumulative_index_point[work_entry->layer];
+					tfxU32 sprite_depth_index = bank.depth_index[index + j] + pm.cumulative_index_point[work_entry->layer] + captured_offset;
 					TFX_ASSERT(sprite_depth_index < work_entry->sprite_instances->current_size);
 					sprites_2d[sprite_depth_index].position.w = rotations_z.a[j];
 					running_sprite_index++;
@@ -13844,6 +13849,7 @@ void ControlParticleSpin3d(tfx_work_queue_t *queue, void *data) {
 	tfx_emitter_state_t &emitter = pm.emitters[work_entry->emitter_index];
 	tfx_particle_soa_t &bank = pm.particle_arrays[emitter.particles_index];
 	const tfx_emission_type emission_type = work_entry->properties->emission_type;
+	tfxU32 captured_offset = (pm.flags & tfxParticleManagerFlags_use_effect_sprite_buffers) ? pm.effects[emitter.root_index].instance_data.instance_start_index : 0;
 
 	const tfxWideInt spin_last_frame = tfxWideSetSinglei(work_entry->graphs->spin.lookup.last_frame);
 	const tfxWideInt spin_pitch_last_frame = tfxWideSetSinglei(work_entry->graphs->pitch_spin.lookup.last_frame);
@@ -13913,7 +13919,7 @@ void ControlParticleSpin3d(tfx_work_queue_t *queue, void *data) {
 		tfxU32 limit_index = running_sprite_index + tfxDataWidth > work_entry->sprite_buffer_end_index ? work_entry->sprite_buffer_end_index - running_sprite_index : tfxDataWidth;
 		if (is_ordered) {    //Predictable
 			for (tfxU32 j = start_diff; j < tfxMin(limit_index + start_diff, tfxDataWidth); ++j) {
-				tfxU32 sprite_depth_index = bank.depth_index[index + j] + pm.cumulative_index_point[work_entry->layer];
+				tfxU32 sprite_depth_index = bank.depth_index[index + j] + pm.cumulative_index_point[work_entry->layer] + captured_offset;
 				TFX_ASSERT(sprite_depth_index < work_entry->sprite_instances->current_size);
 				sprites[sprite_depth_index].rotations.x = rotations_x.a[j];
 				sprites[sprite_depth_index].rotations.y = rotations_y.a[j];
@@ -13941,6 +13947,7 @@ void ControlParticleSize(tfx_work_queue_t *queue, void *data) {
 	tfx_particle_manager_t &pm = *work_entry->pm;
 	tfx_emitter_state_t &emitter = pm.emitters[work_entry->emitter_index];
 	tfx_particle_soa_t &bank = pm.particle_arrays[emitter.particles_index];
+	tfxU32 captured_offset = (pm.flags & tfxParticleManagerFlags_use_effect_sprite_buffers) ? pm.effects[emitter.root_index].instance_data.instance_start_index : 0;
 
 	const tfxWideInt width_last_frame = tfxWideSetSinglei(work_entry->graphs->width.lookup.last_frame);
 	const tfxWideInt height_last_frame = tfxWideSetSinglei(work_entry->graphs->height.lookup.last_frame);
@@ -14036,7 +14043,7 @@ void ControlParticleSize(tfx_work_queue_t *queue, void *data) {
 			tfx_sprite_instance_t *sprites = tfxCastBuffer(tfx_sprite_instance_t, work_entry->sprite_instances);
 			if (is_ordered) {    //Predictable
 				for (tfxU32 j = start_diff; j < tfxMin(limit_index + start_diff, tfxDataWidth); ++j) {
-					tfxU32 sprite_depth_index = bank.depth_index[index + j] + pm.cumulative_index_point[work_entry->layer];
+					tfxU32 sprite_depth_index = bank.depth_index[index + j] + pm.cumulative_index_point[work_entry->layer] + captured_offset;
 					TFX_ASSERT(sprite_depth_index < work_entry->sprite_instances->current_size);
 					sprites[sprite_depth_index].size_handle.packed = packed_scale.a[j] | emitter.image_handle_packed;
 					running_sprite_index++;
@@ -14059,6 +14066,7 @@ void ControlParticleColor(tfx_work_queue_t *queue, void *data) {
 	tfx_particle_manager_t &pm = *work_entry->pm;
 	tfx_emitter_state_t &emitter = pm.emitters[work_entry->emitter_index];
 	tfx_particle_soa_t &bank = work_entry->pm->particle_arrays[emitter.particles_index];
+	tfxU32 captured_offset = (pm.flags & tfxParticleManagerFlags_use_effect_sprite_buffers) ? pm.effects[emitter.root_index].instance_data.instance_start_index : 0;
 
 	const tfxWideFloat global_intensity = tfxWideSetSingle(work_entry->global_intensity);
 
@@ -14113,7 +14121,7 @@ void ControlParticleColor(tfx_work_queue_t *queue, void *data) {
 		if (pm.flags & tfxParticleManagerFlags_3d_effects) { //Predictable
 			tfx_billboard_instance_t *sprites = tfxCastBuffer(tfx_billboard_instance_t, work_entry->sprite_instances);
 			if (is_ordered) {
-				WriteParticleColorSpriteDataOrdered(sprites, pm, work_entry->layer, start_diff, limit_index, bank.depth_index, index, packed_intensity_life, curved_alpha, running_sprite_index);
+				WriteParticleColorSpriteDataOrdered(sprites, pm, work_entry->layer, start_diff, limit_index, bank.depth_index, index, packed_intensity_life, curved_alpha, running_sprite_index, captured_offset);
 			}
 			else {
 				WriteParticleColorSpriteData(sprites, start_diff, limit_index,bank.depth_index, index, packed_intensity_life, curved_alpha, running_sprite_index);
@@ -14122,7 +14130,7 @@ void ControlParticleColor(tfx_work_queue_t *queue, void *data) {
 		else {
 			tfx_sprite_instance_t *sprites = tfxCastBuffer(tfx_sprite_instance_t, work_entry->sprite_instances);
 			if (is_ordered) {
-				WriteParticleColorSpriteDataOrdered(sprites, pm, work_entry->layer, start_diff, limit_index, bank.depth_index, index, packed_intensity_life, curved_alpha, running_sprite_index);
+				WriteParticleColorSpriteDataOrdered(sprites, pm, work_entry->layer, start_diff, limit_index, bank.depth_index, index, packed_intensity_life, curved_alpha, running_sprite_index, captured_offset);
 			}
 			else {
 				WriteParticleColorSpriteData(sprites, start_diff, limit_index, bank.depth_index, index, packed_intensity_life, curved_alpha, running_sprite_index);
@@ -14205,7 +14213,7 @@ void ControlParticleImageFrame(tfx_work_queue_t *queue, void *data) {
 				WriteParticleImageSpriteDataOrdered(sprites, pm, layer, start_diff, limit_index, bank, flags, image_indexes, emitter_flags, billboard_option, index, running_sprite_index, captured_offset);
 			}
 			else {
-				WriteParticleImageSpriteData(sprites, pm, layer, start_diff, limit_index, bank, flags, image_indexes, emitter_flags, billboard_option, index, running_sprite_index, captured_offset);
+				WriteParticleImageSpriteData(sprites, pm, layer, start_diff, limit_index, bank, flags, image_indexes, emitter_flags, billboard_option, index, running_sprite_index);
 			}
 		}
 		else {
@@ -14213,7 +14221,7 @@ void ControlParticleImageFrame(tfx_work_queue_t *queue, void *data) {
 			if (is_ordered) {
 				WriteParticleImageSpriteDataOrdered(sprites, pm, layer, start_diff, limit_index, bank, flags, image_indexes, emitter_flags, billboard_option, index, running_sprite_index, captured_offset);
 			} else {
-				WriteParticleImageSpriteData(sprites, pm, layer, start_diff, limit_index, bank, flags, image_indexes, emitter_flags, billboard_option, index, running_sprite_index, captured_offset);
+				WriteParticleImageSpriteData(sprites, pm, layer, start_diff, limit_index, bank, flags, image_indexes, emitter_flags, billboard_option, index, running_sprite_index);
 			}
 		}
 
@@ -14247,6 +14255,7 @@ void ControlParticleUID(tfx_work_queue_t *queue, void *data) {
 	tfx_particle_manager_t &pm = *work_entry->pm;
 	tfx_emitter_state_t &emitter = pm.emitters[work_entry->emitter_index];
 	tfx_particle_soa_t &bank = pm.particle_arrays[emitter.particles_index];
+	tfxU32 captured_offset = (pm.flags & tfxParticleManagerFlags_use_effect_sprite_buffers) ? pm.effects[emitter.root_index].instance_data.instance_start_index : 0;
 
 	tfxU32 start_diff = work_entry->start_diff;
 
@@ -14263,7 +14272,7 @@ void ControlParticleUID(tfx_work_queue_t *queue, void *data) {
 		if (is_ordered) {                //Predictable
 			for (tfxU32 j = start_diff; j < tfxMin(limit_index + start_diff, tfxDataWidth); ++j) {
 				int index_j = index + j;
-				tfxU32 sprite_depth_index = bank.depth_index[index_j] + pm.cumulative_index_point[work_entry->layer];
+				tfxU32 sprite_depth_index = bank.depth_index[index_j] + pm.cumulative_index_point[work_entry->layer] + captured_offset;
 				bool new_id = bank.age[index_j] == 0 && bank.single_loop_count[index_j] > 0 && !is_wrapped ? true : false;
 				sprite_uids[sprite_depth_index].uid = new_id ? (tfxU32)tfx__rdtsc() : bank.uid[index_j];
 				bank.uid[index_j] = sprite_uids[sprite_depth_index].uid;

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -11764,6 +11764,8 @@ void UpdateParticleManager(tfx_particle_manager_t *pm, float elapsed_time) {
 
 	pm->control_emitter_queue.clear();
 
+	tfxU32 last_instance_count = 0;
+
 	//Loop over all the effects and emitters, depth by depth, and add spawn jobs to the worker queue
 	for (int depth = 0; depth != tfxMAXDEPTH; ++depth) {
 
@@ -11844,6 +11846,8 @@ void UpdateParticleManager(tfx_particle_manager_t *pm, float elapsed_time) {
 				} else {
 					memset(instance_data.cumulative_index_point, 0, sizeof(tfxU32) * tfxLAYERS);
 				}
+				instance_data.instance_start_index = last_instance_count;
+				last_instance_count = instance_data.instance_start_index;
 			}
 		}
 	}

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -12096,12 +12096,6 @@ void UpdateParticleManager(tfx_particle_manager_t *pm, float elapsed_time) {
 			}
 			effects_in_use[j + 1] = key;
 		}
-		tfxU32 running_instance_offset = 0;
-		for (tfxU32 i = 0; i != effects_in_use.current_size; ++i) {
-			tfx_effect_instance_data_t &instance_data = pm->effects[effects_in_use[i].index].instance_data;
-			instance_data.instance_start_index += running_instance_offset;
-			running_instance_offset += instance_data.instance_count;
-		}
 	}
 
 	if (pm->flags & tfxParticleManagerFlags_update_bounding_boxes) {
@@ -14181,6 +14175,7 @@ void ControlParticleImageFrame(tfx_work_queue_t *queue, void *data) {
 	tfx_control_work_entry_t *work_entry = static_cast<tfx_control_work_entry_t *>(data);
 	tfx_particle_manager_t &pm = *work_entry->pm;
 	tfx_emitter_state_t &emitter = pm.emitters[work_entry->emitter_index];
+	tfxU32 captured_offset = (pm.flags & tfxParticleManagerFlags_use_effect_sprite_buffers) ? pm.effects[emitter.root_index].instance_data.instance_start_index : 0;
 	tfx_particle_soa_t &bank = pm.particle_arrays[emitter.particles_index];
 	tfx_image_data_t *image = work_entry->properties->image;
 	const tfx_billboarding_option billboard_option = work_entry->properties->billboard_option;
@@ -14244,18 +14239,18 @@ void ControlParticleImageFrame(tfx_work_queue_t *queue, void *data) {
 		if (pm.flags & tfxParticleManagerFlags_3d_effects) { //Predictable
 			tfx_billboard_instance_t *sprites = tfxCastBuffer(tfx_billboard_instance_t, work_entry->sprite_instances);
 			if (is_ordered) {
-				WriteParticleImageSpriteDataOrdered(sprites, pm, layer, start_diff, limit_index, bank, flags, image_indexes, emitter_flags, billboard_option, index, running_sprite_index);
+				WriteParticleImageSpriteDataOrdered(sprites, pm, layer, start_diff, limit_index, bank, flags, image_indexes, emitter_flags, billboard_option, index, running_sprite_index, captured_offset);
 			}
 			else {
-				WriteParticleImageSpriteData(sprites, pm, layer, start_diff, limit_index, bank, flags, image_indexes, emitter_flags, billboard_option, index, running_sprite_index);
+				WriteParticleImageSpriteData(sprites, pm, layer, start_diff, limit_index, bank, flags, image_indexes, emitter_flags, billboard_option, index, running_sprite_index, captured_offset);
 			}
 		}
 		else {
 			tfx_sprite_instance_t *sprites = tfxCastBuffer(tfx_sprite_instance_t, work_entry->sprite_instances);
 			if (is_ordered) {
-				WriteParticleImageSpriteDataOrdered(sprites, pm, layer, start_diff, limit_index, bank, flags, image_indexes, emitter_flags, billboard_option, index, running_sprite_index);
+				WriteParticleImageSpriteDataOrdered(sprites, pm, layer, start_diff, limit_index, bank, flags, image_indexes, emitter_flags, billboard_option, index, running_sprite_index, captured_offset);
 			} else {
-				WriteParticleImageSpriteData(sprites, pm, layer, start_diff, limit_index, bank, flags, image_indexes, emitter_flags, billboard_option, index, running_sprite_index);
+				WriteParticleImageSpriteData(sprites, pm, layer, start_diff, limit_index, bank, flags, image_indexes, emitter_flags, billboard_option, index, running_sprite_index, captured_offset);
 			}
 		}
 

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -5560,7 +5560,7 @@ tfx_gpu_shapes_t BuildGPUShapeData(tfx_vector_t<tfx_image_data_t> *particle_shap
 	TFX_ASSERT(particle_shapes->size());        //There are no shapes to copy!
 	tfxU32 index = 0;
 	tfx_gpu_shapes_t shape_data;
-	for (auto &shape : *particle_shapes) {
+	for (tfx_image_data_t &shape : *particle_shapes) {
 		if (shape.animation_frames == 1) {
 			tfx_gpu_image_data_t cs;
 			cs.animation_frames = shape.animation_frames;

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -10689,11 +10689,11 @@ void RecordSpriteData(tfx_particle_manager_t *pm, tfx_effect_emitter_t *effect, 
 	}
 
 	if (is_3d) {
-		for (int i = 1; i != anim.real_frames; ++i) {
+		for (int i = 0; i != anim.real_frames; ++i) {
 			SpriteDataOffsetCapturedIndexes(sprite_data->real_time_sprites.billboard_instance, sprite_data, i, anim.real_frames);
 		}
 	} else {
-		for (int i = 1; i != anim.real_frames; ++i) {
+		for (int i = 0; i != anim.real_frames; ++i) {
 			SpriteDataOffsetCapturedIndexes(sprite_data->real_time_sprites.sprite_instance, sprite_data, i, anim.real_frames);
 		}
 	}

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -14023,7 +14023,7 @@ void ControlParticleSize(tfx_work_queue_t *queue, void *data) {
 			tfx_billboard_instance_t *sprites = tfxCastBuffer(tfx_billboard_instance_t, work_entry->sprite_instances);
 			if (is_ordered) {    //Predictable
 				for (tfxU32 j = start_diff; j < tfxMin(limit_index + start_diff, tfxDataWidth); ++j) {
-					tfxU32 sprite_depth_index = bank.depth_index[index + j] + pm.cumulative_index_point[work_entry->layer];
+					tfxU32 sprite_depth_index = bank.depth_index[index + j] + pm.cumulative_index_point[work_entry->layer] + captured_offset;
 					TFX_ASSERT(sprite_depth_index < work_entry->sprite_instances->current_size);
 					sprites[sprite_depth_index].size_handle.packed = packed_scale.a[j] | emitter.image_handle_packed;
 					running_sprite_index++;

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -6449,15 +6449,17 @@ void CompileLibraryVariationGraph(tfx_library_t *library, tfxU32 index) {
 	CompileGraph(&g.weight);
 }
 
-void CompileLibraryOvertimeGraph(tfx_library_t *library, tfxU32 index) {
+void CompileLibraryOvertimeGraph(tfx_library_t *library, tfxU32 index, bool including_color_graphs) {
 	tfx_overtime_attributes_t &g = library->emitter_attributes[index].overtime;
-	g.color_ramps[0] = CompileColorRamp(&g);
-	g.color_ramps[1] = CompileColorRampHint(&g);
-	EditColorRampBitmap(library, &g, 0);
-	EditColorRampBitmap(library, &g, 1);
-	CompileGraphOvertime(&g.intensity);
-	CompileGraphOvertime(&g.alpha_sharpness);
-	CompileGraphOvertime(&g.curved_alpha);
+	if (including_color_graphs) {
+		g.color_ramps[0] = CompileColorRamp(&g);
+		g.color_ramps[1] = CompileColorRampHint(&g);
+		EditColorRampBitmap(library, &g, 0);
+		EditColorRampBitmap(library, &g, 1);
+		CompileGraphOvertime(&g.intensity);
+		CompileGraphOvertime(&g.alpha_sharpness);
+		CompileGraphOvertime(&g.curved_alpha);
+	}
 	CompileGraphOvertime(&g.velocity_turbulance);
 	CompileGraphOvertime(&g.width);
 	CompileGraphOvertime(&g.height);

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -15255,8 +15255,8 @@ tfxU32 SpawnParticles(tfx_particle_manager_t *pm, tfx_spawn_work_entry_t *work_e
 	tfx_emitter_state_t &emitter = pm->emitters[work_entry->emitter_index];
 	const tfx_emitter_properties_t &properties = *work_entry->properties;
 	const tfxU32 layer = properties.layer;
-
-	if (emitter.state_flags & tfxEmitterStateFlags_single_shot_done || emitter.state_flags & tfxEmitterStateFlags_stop_spawning || pm->effects[work_entry->parent_index].state_flags & tfxEffectStateFlags_stop_spawning)
+	// Note that adding this in will mess up other emitter emission types and looped sprite recording || pm->effects[work_entry->parent_index].state_flags & tfxEffectStateFlags_stop_spawning
+	if (emitter.state_flags & tfxEmitterStateFlags_single_shot_done || emitter.state_flags & tfxEmitterStateFlags_stop_spawning)
 		return 0;
 	if (emitter.spawn_quantity == 0)
 		return 0;

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -15278,7 +15278,6 @@ void UpdatePMEmitter(tfx_work_queue_t *work_queue, void *data) {
 		instance_buffer.current_size += max_spawn_count + emitter.sprites_count;
 		emitter.sprites_count += max_spawn_count;
 		emitter.sprites_index = sprite_index_point;
-		tfxPrint("Sprint index point: %i", sprite_index_point);
 		sprite_index_point += emitter.sprites_count;
 
 		if (emitter.state_flags & tfxEmitterStateFlags_is_sub_emitter) {

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -13262,7 +13262,7 @@ void ControlParticleTransform3d(tfx_work_queue_t *queue, void *data) {
 		if (is_ordered) {
 			for (tfxU32 j = start_diff; j < tfxMin(limit_index + start_diff, tfxDataWidth); ++j) {
 				int index_j = index + j;
-				tfxU32 sprite_depth_index = bank.depth_index[index_j] + pm.cumulative_index_point[work_entry->layer];
+				tfxU32 sprite_depth_index = bank.depth_index[index_j] + pm.cumulative_index_point[work_entry->layer] + captured_offset;
 				sprites[sprite_depth_index].alignment.packed = alignment_packed.a[j];
 				sprites[sprite_depth_index].position.w = p_stretch.a[j];
 				sprites[sprite_depth_index].position.x = position_x.a[j];
@@ -13272,7 +13272,7 @@ void ControlParticleTransform3d(tfx_work_queue_t *queue, void *data) {
 				bank.captured_position_y[index_j] = sprites[sprite_depth_index].position.y;
 				bank.captured_position_z[index_j] = sprites[sprite_depth_index].position.z;
 				tfx_vec3_t sprite_plus_camera_position = sprites[sprite_depth_index].position.xyz() - pm.camera_position;
-				(*work_entry->depth_indexes)[sprite_depth_index - pm.cumulative_index_point[work_entry->layer]].depth = LengthVec3NoSqR(&sprite_plus_camera_position);
+				(*work_entry->depth_indexes)[sprite_depth_index - pm.cumulative_index_point[work_entry->layer] - captured_offset].depth = LengthVec3NoSqR(&sprite_plus_camera_position);
 				if (pm.flags & tfxParticleManagerFlags_update_bounding_boxes) {
 					bounding_box.min_corner.x = tfx__Min(position_x.a[j], bounding_box.min_corner.x);
 					bounding_box.min_corner.y = tfx__Min(position_y.a[j], bounding_box.min_corner.y);

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -10585,6 +10585,15 @@ void RecordSpriteData(tfx_particle_manager_t *pm, tfx_effect_emitter_t *effect, 
 		bool particles_processed_last_frame = false;
 
 		if (offset >= start_frame) {
+			if (offset == start_frame && start_frame > 0) {
+				for (tfxEachLayer) {
+					if (is_3d) {
+						InvalidateOffsettedSpriteCapturedIndex(tfxCastBufferRef(tfx_billboard_instance_t, pm->instance_buffer_for_recording[pm->current_sprite_buffer][layer]), pm->unique_sprite_ids[pm->current_sprite_buffer][layer], pm, layer);
+					} else {
+						InvalidateOffsettedSpriteCapturedIndex(tfxCastBufferRef(tfx_sprite_instance_t, pm->instance_buffer_for_recording[pm->current_sprite_buffer][layer]), pm->unique_sprite_ids[pm->current_sprite_buffer][layer], pm, layer);
+					}
+				}
+			}
 			for (tfxEachLayer) {
 				if (running_count[layer][frame] > 0 && pm->layer_sizes[layer] > 0) {
 					//Copy instance_data that have looped round (for looped effects) into a temporary buffer, to be copied back after the fresh instance_data have been copied

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -14115,7 +14115,7 @@ void ControlParticleColor(tfx_work_queue_t *queue, void *data) {
 	color_ramp_indexes.m = tfxWideOri(color_ramp_indexes.m, tfxWideSetSinglei(tfxColorRampLayer(work_entry->graphs->color_ramp_bitmap_indexes[0]) << 16));
 	color_ramp_indexes.m = tfxWideOri(color_ramp_indexes.m, tfxWideSetSinglei(tfxColorRampIndex(work_entry->graphs->color_ramp_bitmap_indexes[1]) << 8));
 	color_ramp_indexes.m = tfxWideOri(color_ramp_indexes.m, tfxWideSetSinglei(tfxColorRampLayer(work_entry->graphs->color_ramp_bitmap_indexes[1])));
-	tfxWideInt texture_layer = {tfxWideShiftLeft(tfxWideSetSinglei(work_entry->properties->image->image_index), 8)};
+	//tfxWideInt texture_layer = {tfxWideShiftLeft(tfxWideSetSinglei(work_entry->properties->image->image_index), 8)};
 
 	int test_index1 = tfxColorRampIndex(work_entry->graphs->color_ramp_bitmap_indexes[0]);
 	int test_layer1 = tfxColorRampLayer(work_entry->graphs->color_ramp_bitmap_indexes[0]);
@@ -14158,7 +14158,7 @@ void ControlParticleColor(tfx_work_queue_t *queue, void *data) {
 
 		tfxWideArrayi packed_lerp_values = { tfxWideShiftLeft(ramp_index.m, 24) };
 		packed_lerp_values.m = tfxWideOri(packed_lerp_values.m, tfxWideShiftLeft(lookup_color_mix, 16));
-		packed_lerp_values.m = tfxWideOri(packed_lerp_values.m, texture_layer);
+		//packed_lerp_values.m = tfxWideOri(packed_lerp_values.m, texture_layer);
 
 		tfxWideArrayi packed_intensities = { PackWide16bit2SScaled(lookup_intensity, hint_intensity, 128.f) };
 
@@ -14215,6 +14215,7 @@ void ControlParticleImageFrame(tfx_work_queue_t *queue, void *data) {
 	tfxEmitterStateFlags property_flags = emitter.property_flags;
 	const tfxWideInt xor_capture_after_transform_flag = tfxWideXOri(tfxWideSetSinglei(tfxParticleFlags_capture_after_transform), tfxWideSetSinglei(-1));
 	const tfxWideInt capture_after_transform_flag = tfxWideSetSinglei(tfxParticleFlags_capture_after_transform);
+	tfxWideInt texture_layer = {tfxWideShiftLeft(tfxWideSetSinglei(work_entry->properties->image->image_index), 8)};
 
 	tfxU32 running_sprite_index = work_entry->sprites_index;
 	tfx_sprite_soa_t &sprites = *work_entry->sprites;

--- a/timelinefx.cpp
+++ b/timelinefx.cpp
@@ -87,12 +87,23 @@ tfx_allocator *tfxGetAllocator() {
 
 tfx_bool tfx_SafeCopy(void *dst, void *src, tfx_size size) {
 	tfx_header *block = tfx__block_from_allocation(dst);
-	if (block->size < size) {
+	if (size > block->size) {
 		return 0;
 	}
 	tfx_header *next_physical_block = tfx__next_physical_block(block);
 	ptrdiff_t diff_check = (ptrdiff_t)((char *)dst + size) - (ptrdiff_t)next_physical_block;
-	if (diff_check >= 0) {
+	if (diff_check > 0) {
+		return 0;
+	}
+	memcpy(dst, src, size);
+	return 1;
+}
+
+tfx_bool tfx_SafeCopyBlock(void *dst_block_start, void *dst, void *src, tfx_size size) {
+	tfx_header *block = tfx__block_from_allocation(dst_block_start);
+	tfx_header *next_physical_block = tfx__next_physical_block(block);
+	ptrdiff_t diff_check = (ptrdiff_t)((char *)dst + size) - (ptrdiff_t)next_physical_block;
+	if (diff_check > 0) {
 		return 0;
 	}
 	memcpy(dst, src, size);

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -7028,7 +7028,7 @@ tfxAPI_EDITOR void CompileLibraryEmitterGraphs(tfx_library_t *library, tfxU32 in
 tfxAPI_EDITOR void CompileLibraryPropertyGraph(tfx_library_t *library, tfxU32 index);
 tfxAPI_EDITOR void CompileLibraryBaseGraph(tfx_library_t *library, tfxU32 index);
 tfxAPI_EDITOR void CompileLibraryVariationGraph(tfx_library_t *library, tfxU32 index);
-tfxAPI_EDITOR void CompileLibraryOvertimeGraph(tfx_library_t *library, tfxU32 index);
+tfxAPI_EDITOR void CompileLibraryOvertimeGraph(tfx_library_t *library, tfxU32 index, bool including_color_graphs = true);
 tfxAPI_EDITOR void CompileLibraryFactorGraph(tfx_library_t *library, tfxU32 index);
 tfxAPI_EDITOR void CompileLibraryColorGraphs(tfx_library_t *library, tfxU32 index);
 tfxAPI_EDITOR void CompileLibraryGraphsOfEffect(tfx_library_t *library, tfx_effect_emitter_t *effect, tfxU32 depth = 0);

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -5509,7 +5509,6 @@ struct tfx_effect_state_t {
 	tfx_vec3_t captured_position;
 	tfx_vec3_t local_rotations;
 	tfx_vec3_t world_rotations;
-	//Todo: save space and use a quaternion here?
 	tfx_bounding_box_t bounding_box;
 
 	tfxU32 global_attributes;
@@ -5711,7 +5710,7 @@ struct tfx_sprite_instance_t {						//44 bytes
 	tfxU32 curved_alpha;							//Sharpness and dissolve amount value for fading the image
 	tfxU32 indexes;									//[color ramp y index, color ramp texture array index, capture flag (1 bit << 15), billboard alignment (2 bits << 13), image data index max 8191 images]
 	tfxU32 captured_index;							//Index to the sprite in the buffer from the previous frame for interpolation
-	tfxU32 padding;
+	tfxU32 uid;
 };
 
 struct tfx_billboard_instance_t {					//56 bytes
@@ -6674,9 +6673,9 @@ inline void WriteParticleImageSpriteData(T *sprites, tfx_particle_manager_t &pm,
 		int index_j = index + j;
 		tfxU32 &sprites_index = bank.sprite_index[index_j];
 		tfxU32 capture = flags.a[j];
-		sprites[running_sprite_index].captured_index = capture == 0 ? (pm.current_sprite_buffer << 30) + running_sprite_index : (!pm.current_sprite_buffer << 30) + (sprites_index & 0x0FFFFFFF);
+		sprites[running_sprite_index].captured_index = capture == 0 ? running_sprite_index : sprites_index;
 		sprites[running_sprite_index].captured_index |= property_flags & tfxEmitterPropertyFlags_wrap_single_sprite ? 0x80000000 : 0;
-		sprites_index = layer + running_sprite_index;
+		sprites_index = running_sprite_index;
 		sprites[running_sprite_index].indexes = image_indexes.a[j];
 		sprites[running_sprite_index].indexes |= (billboard_option << 13) | capture;
 		bank.flags[index_j] &= ~tfxParticleFlags_capture_after_transform;
@@ -7029,7 +7028,7 @@ tfxINTERNAL unsigned int GetControllerMemoryUsage(tfx_particle_manager_t *pm);
 tfxINTERNAL unsigned int GetParticleMemoryUsage(tfx_particle_manager_t *pm);
 tfxINTERNAL void FreeComputeSlot(tfx_particle_manager_t *pm, unsigned int slot_id);
 tfxINTERNAL tfxEffectID AddEffectToParticleManager(tfx_particle_manager_t *pm, tfx_effect_emitter_t *effect, int buffer, int hierarchy_depth, bool is_sub_emitter, tfxU32 root_effect_index, float add_delayed_spawning);
-tfxINTERNAL void ToggleSpritesWithUID(tfx_particle_manager_t *pm, bool switch_on);
+tfxAPI_EDITOR void ToggleSpritesWithUID(tfx_particle_manager_t *pm, bool switch_on);
 tfxINTERNAL void FreeParticleList(tfx_particle_manager_t *pm, tfxU32 index);
 tfxINTERNAL void FreeEffectSpriteList(tfx_particle_manager_t *pm, tfxU32 index);
 tfxINTERNAL void FreeSpawnLocationList(tfx_particle_manager_t *pm, tfxU32 index);

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -5549,9 +5549,11 @@ struct tfx_depth_index_t {
 	float depth;
 };
 
-//Used when a particle manager is grouping instance_data by effect. This way effects can be individually ordered and drawn/not drawn in order however you need
+//Used when a particle manager is grouping instances by effect. This way effects can be individually ordered and drawn/not drawn in order however you need
 struct tfx_effect_instance_data_t {
 	tfx_vector_t<tfx_depth_index_t> depth_indexes[tfxLAYERS][2];
+	tfxU32 sprite_index_point[tfxLAYERS];
+	tfxU32 cumulative_index_point[tfxLAYERS];
 	tfxU32 depth_starting_index[tfxLAYERS];
 	tfxU32 current_depth_buffer_index[tfxLAYERS];
 	tfxU32 instance_start_index;
@@ -5982,6 +5984,8 @@ struct tfx_control_work_entry_t {
 	tfxU32 wide_end_index;
 	tfxU32 start_diff;
 	tfxU32 sprites_index;
+	tfxU32 cumulative_index_point;
+	tfxU32 effect_instance_offset;
 	tfxU32 sprite_buffer_end_index;
 	tfxU32 emitter_index;
 	tfx_particle_manager_t *pm;

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -5640,6 +5640,7 @@ struct tfx_compute_sprite_t {    //64 bytes
 struct tfx_unique_sprite_id_t {
 	tfxU32 uid;
 	tfxU32 age;
+	tfxU32 property_index;
 };
 
 //These all point into a tfx_soa_buffer_t, initialised with InitParticleSoA. Current Bandwidth: 108 bytes
@@ -5725,6 +5726,7 @@ struct tfx_sprite_instance_t {						//48 bytes
 	tfxU32 curved_alpha;							//Sharpness and dissolve amount value for fading the image 2 16bit floats packed
 	tfxU32 indexes;									//[color ramp y index, color ramp texture array index, capture flag, image data index (1 bit << 15), billboard alignment (2 bits << 13), image data index max 8191 images]
 	tfxU32 captured_index;							//Index to the sprite in the buffer from the previous frame for interpolation
+	tfxU32 padding;
 };
 
 struct tfx_billboard_instance_t {					//56 bytes
@@ -5771,7 +5773,8 @@ struct alignas(16) tfx_sprite_data3d_t {    //60 bytes aligning to 64
 	tfxU32 curved_alpha;							//Sharpness and dissolve amount value for fading the image 2 16bit floats packed
 	tfxU32 indexes;									//[color ramp y index, color ramp texture array index, capture flag, image data index (1 bit << 15), billboard alignment (2 bits << 13), image data index max 8191 images]
 	tfxU32 captured_index;							//Index to the sprite in the buffer from the previous frame for interpolation
-	float lerp_offset;								
+	tfxU32 additional;								//Padding, but also used to pack lerp offset and property index
+	tfxU32 padding;
 };
 
 struct alignas(16) tfx_sprite_data2d_t {    //48 bytes
@@ -5782,7 +5785,7 @@ struct alignas(16) tfx_sprite_data2d_t {    //48 bytes
 	tfxU32 curved_alpha;							//Sharpness and dissolve amount value for fading the image 2 16bit floats packed
 	tfxU32 indexes;									//[color ramp y index, color ramp texture array index, capture flag, image data index (1 bit << 15), billboard alignment (2 bits << 13), image data index max 8191 images]
 	tfxU32 captured_index;							//Index to the sprite in the buffer from the previous frame for interpolation
-	float lerp_offset;
+	tfxU32 additional;								//Padding, but also used to pack lerp offset and property index
 };
 
 //Animation sprite data that is used on the cpu to bake the data
@@ -5930,7 +5933,6 @@ struct tfx_control_work_entry_t {
 	tfx_overtime_attributes_t *graphs;
 	tfxU32 layer;
 	tfx_emitter_properties_t *properties;
-	tfx_vector_t<tfx_unique_sprite_id_t> *sprite_uids;
 	tfx_buffer_t *sprite_instances;
 	tfx_vector_t<tfx_depth_index_t> *depth_indexes;
 	tfx_emitter_path_t *path;

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -5606,6 +5606,7 @@ struct tfx_effect_state_t {
 
 	//The emitters within this effect.
 	tfx_vector_t<tfxU32> emitter_indexes[2];
+	tfxU32 emitter_start_size;
 
 	//User Data
 	void *user_data;
@@ -6230,7 +6231,6 @@ struct tfx_particle_manager_t {
 	tfxU32 effect_index_position;
 
 	tfxU32 effects_start_size[tfxMAXDEPTH];
-	tfxU32 emitter_start_size[tfxMAXDEPTH];
 
 	tfxU32 sprite_index_point[tfxLAYERS];
 	tfxU32 cumulative_index_point[tfxLAYERS];
@@ -6238,6 +6238,7 @@ struct tfx_particle_manager_t {
 
 	int mt_batch_size;
 	std::mutex particle_index_mutex;
+	std::mutex add_effect_mutex;
 
 	tfx_random_t random;
 	tfx_random_t threaded_random;

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -6122,20 +6122,20 @@ struct tfx_effect_index_t {
 };
 
 struct tfx_particle_manager_info_t {
-	tfxU32 layer_max_values[tfxLAYERS];        //The maximum number of sprites for each layer. This setting is not relevent if dynamic_sprite_allocation is set to true or group_sprites_by_effect is true.
-	tfxU32 max_effects;                        //The maximum number of effects that can be updated at the same time.
-	tfx_particle_manager_mode order_mode;    //When not grouping sprites by effect, you can set the mode of the particle manager to order sprites or not.
-	//When set to false, all sprites will be kept together in a large list.
-	tfxU32 multi_threaded_batch_size;        //The size of each batch of particles to be processed when multithreading. Must be a power of 2 and 256 or greater.
-	tfxU32 sort_passes;                        //when in order by depth mode (not guaranteed order) set the number of sort passes for more accuracy. Anything above 5 and you should just be guaranteed order.
-	bool double_buffer_sprites;                //Set to true to double buffer sprites so that you can interpolate between the old and new positions for smoother animations.
-	bool dynamic_sprite_allocation;            //Set to true to automatically resize the sprite buffers if they run out of space. Not applicable when grouping sprites by effect.
-	bool group_sprites_by_effect;            //Set to true to group all sprites by effect. Effects can then be drawn in specific orders or not drawn at all on an effect by effect basis.
+	tfxU32 max_particles;					//The maximum number of sprites for each layer. This setting is not relevent if dynamic_sprite_allocation is set to true or group_sprites_by_effect is true.
+	tfxU32 max_effects;                     //The maximum number of effects that can be updated at the same time.
+	tfx_particle_manager_mode order_mode;   //When not grouping sprites by effect, you can set the mode of the particle manager to order sprites or not.
+											//When set to false, all sprites will be kept together in a large list.
+	tfxU32 multi_threaded_batch_size;       //The size of each batch of particles to be processed when multithreading. Must be a power of 2 and 256 or greater.
+	tfxU32 sort_passes;                     //when in order by depth mode (not guaranteed order) set the number of sort passes for more accuracy. Anything above 5 and you should just be guaranteed order.
+	bool double_buffer_sprites;             //Set to true to double buffer sprites so that you can interpolate between the old and new positions for smoother animations.
+	bool dynamic_sprite_allocation;         //Set to true to automatically resize the sprite buffers if they run out of space. Not applicable when grouping sprites by effect.
+	bool group_sprites_by_effect;           //Set to true to group all sprites by effect. Effects can then be drawn in specific orders or not drawn at all on an effect by effect basis.
 	bool auto_order_effects;                //When group_sprites_by_effect is true then you can set this to true to sort the effects each frame. Use SetPMCamera in 3d to set the effect depth to the distance the camera, in 2d the depth is set to the effect y position.
-	bool is_3d;                                //All effects are 3d
+	bool is_3d;                             //All effects are 3d
 
 	tfx_particle_manager_info_t() :
-		layer_max_values{},
+		max_particles(10000),
 		max_effects(1000),
 		order_mode(tfxParticleManagerMode_unordered),
 		multi_threaded_batch_size(4096),
@@ -6184,7 +6184,7 @@ struct tfx_particle_manager_t {
 
 	//Banks of sprites. All emitters write their sprite data to these banks. 
 	tfx_vector_t <tfx_unique_sprite_id_t> unique_sprite_ids[2][tfxLAYERS];
-	tfx_buffer_t instance_buffer[2];
+	tfx_buffer_t instance_buffer;
 	tfx_buffer_t instance_buffer_for_recording[2][tfxLAYERS];
 	tfxU32 current_sprite_buffer;
 	tfxU32 highest_depth_index;
@@ -7200,7 +7200,7 @@ tfxINTERNAL tfx_compute_particle_t *GrabComputeParticle(tfx_particle_manager_t *
 tfxINTERNAL void ResetParticlePtr(tfx_particle_manager_t *pm, void *ptr);
 tfxINTERNAL void ResetControllerPtr(tfx_particle_manager_t *pm, void *ptr);
 tfxINTERNAL void UpdateCompute(tfx_particle_manager_t *pm, void *sampled_particles, unsigned int sample_size = 100);
-tfxINTERNAL void InitCommonParticleManager(tfx_particle_manager_t *pm, tfx_library_t *library, tfxU32 layer_max_values[tfxLAYERS], unsigned int effects_limit, tfx_particle_manager_mode mode, bool double_buffered_sprites, bool dynamic_sprite_allocation, bool group_sprites_by_effect, tfxU32 mt_batch_size);
+tfxINTERNAL void InitCommonParticleManager(tfx_particle_manager_t *pm, tfx_library_t *library, tfxU32 max_particles[tfxLAYERS], unsigned int effects_limit, tfx_particle_manager_mode mode, bool double_buffered_sprites, bool dynamic_sprite_allocation, bool group_sprites_by_effect, tfxU32 mt_batch_size);
 tfxINTERNAL bool ValidEffectID(tfx_particle_manager_t *pm, tfxEffectID id);
 
 //--------------------------------
@@ -7510,79 +7510,79 @@ tfxAPI tfx_particle_manager_info_t CreateParticleManagerInfo(tfx_particle_manage
 
 /*
 Initialize a particle manager with a tfx_particle_manager_info_t object which contains setup data for how to configure the particle manager. See CreateParticleManagerInfo
-* @param pm                        A pointer to an unitialised tfx_particle_manager_t. If you want to reconfigure a particle manager for a different usage then you can call ReconfigureParticleManager.
+* @param pm						A pointer to an unitialised tfx_particle_manager_t. If you want to reconfigure a particle manager for a different usage then you can call ReconfigureParticleManager.
 * @param library                A pointer to a tfx_library_t that you will be using to add all of the effects from to the particle manager.
-* @param info                    A tfx_particle_manager_info_t pointer containing the configuration for the particle manager.
+* @param info                   A tfx_particle_manager_info_t pointer containing the configuration for the particle manager.
 */
 tfxAPI void InitializeParticleManager(tfx_particle_manager_t *pm, tfx_library_t *library, tfx_particle_manager_info_t info);
 
 /*
 Initialise a tfx_particle_manager_t for 3d usage. Also see InitializeParticleManager and CreateParticleManagerInfo as an alternative way to set up a particle manager.
-* @param pm                        A pointer to an unitialised tfx_particle_manager_t. If you want to reconfigure a particle manager for a different usage then you can call ReconfigureParticleManager.
+* @param pm                     A pointer to an unitialised tfx_particle_manager_t. If you want to reconfigure a particle manager for a different usage then you can call ReconfigureParticleManager.
 * @param library                A pointer to a tfx_library_t that you will be using to add all of the effects from to the particle manager.
-* @param layer_max_values        An array of unsigned ints representing the maximum amount of particles you want available for each layer. This will allocate the appropriate amount of memory ahead of time.
-* @param effects_limit            The maximum amount of effects and emitters that can be updated in a single frame. This will allocate the appropriate amount of memory ahead of time. Default: 1000.
-* @param mode                    The operation mode of the particle manager regarding how particles are ordered. Default value: tfxParticleManagerMode_unordered. Possible modes are:
+* @param max_particles          An array of unsigned ints representing the maximum amount of particles you want available for each layer. This will allocate the appropriate amount of memory ahead of time.
+* @param effects_limit          The maximum amount of effects and emitters that can be updated in a single frame. This will allocate the appropriate amount of memory ahead of time. Default: 1000.
+* @param mode                   The operation mode of the particle manager regarding how particles are ordered. Default value: tfxParticleManagerMode_unordered. Possible modes are:
 	tfxParticleManagerMode_unordered                    Particles will be updated by emitter. No ordering is maintained, each emitter will spawn and update their particles in turn and sprites will be ordered
 														according to that sequence.
-	tfxParticleManagerMode_ordered_by_age                Particles will be kept in age order, older particles will be drawn first and newer ones last
-	tfxParticleManagerMode_ordered_by_depth                Particles will be drawn in depth order or distance from the camera. You can specify the number of sort passes when setting up the effects in TimelineFX editor
-	tfxParticleManagerMode_ordered_by_depth_guaranteed    Particles will be sorted each update and kept in depth order
-* @param double_buffer_sprites    True or False, whether the last frame of sprites is kept so that you can use to do interpolations for smoother animation
-* @param dynamic_allocation        If set to true then when the layer_max_values is hit for a layer the sprite and particle memory allocation will be grown dynamically. This can be useful when you're unsure of how
+	tfxParticleManagerMode_ordered_by_age               Particles will be kept in age order, older particles will be drawn first and newer ones last
+	tfxParticleManagerMode_ordered_by_depth             Particles will be drawn in depth order or distance from the camera. You can specify the number of sort passes when setting up the effects in TimelineFX editor
+	tfxParticleManagerMode_ordered_by_depth_guaranteed  Particles will be sorted each update and kept in depth order
+* @param double_buffer_sprites  True or False, whether the last frame of sprites is kept so that you can use to do interpolations for smoother animation
+* @param dynamic_allocation     If set to true then when the max_particles is hit for a layer the sprite and particle memory allocation will be grown dynamically. This can be useful when you're unsure of how
 								many particles you will need to display while developing you're game/app. Default is false.
-* @param mt_batch_size            When using multithreading you can alter the size of each batch of particles that each thread will update. The default is 2048
+* @param mt_batch_size          When using multithreading you can alter the size of each batch of particles that each thread will update. The default is 2048
 
 */
-tfxAPI void InitParticleManagerFor3d(tfx_particle_manager_t *pm, tfx_library_t *library, tfxU32 layer_max_values[tfxLAYERS], unsigned int effects_limit, tfx_particle_manager_mode mode, bool double_buffer_sprites, bool dynamic_allocation, bool group_sprites_by_effect, tfxU32 mt_batch_size);
+tfxAPI void InitParticleManagerFor3d(tfx_particle_manager_t *pm, tfx_library_t *library, tfxU32 max_particles, unsigned int effects_limit, tfx_particle_manager_mode mode, bool double_buffer_sprites, bool dynamic_allocation, bool group_sprites_by_effect, tfxU32 mt_batch_size);
 
 /*
 Initialise a tfx_particle_manager_t for 2d usage
-* @param pm                        A pointer to an unitialised tfx_particle_manager_t. If you want to reconfigure a particle manager for a different usage then you can call ReconfigureParticleManager.
+* @param pm                     A pointer to an unitialised tfx_particle_manager_t. If you want to reconfigure a particle manager for a different usage then you can call ReconfigureParticleManager.
 * @param library                A pointer to a tfx_library_t that you will be using to add all of the effects from to the particle manager.
-* @param layer_max_values        An array of unsigned ints representing the maximum amount of particles you want available for each layer. This will allocate the appropriate amount of memory ahead of time.
-* @param effects_limit            The maximum amount of effects and emitters that can be updated in a single frame. This will allocate the appropriate amount of memory ahead of time. Default: 1000.
-* @param mode                    The operation mode of the particle manager regarding how particles are ordered. Default value: tfxParticleManagerMode_unordered. Possible modes are:
+* @param max_particles          An array of unsigned ints representing the maximum amount of particles you want available for each layer. This will allocate the appropriate amount of memory ahead of time.
+* @param effects_limit          The maximum amount of effects and emitters that can be updated in a single frame. This will allocate the appropriate amount of memory ahead of time. Default: 1000.
+* @param mode                   The operation mode of the particle manager regarding how particles are ordered. Default value: tfxParticleManagerMode_unordered. Possible modes are:
 	tfxParticleManagerMode_unordered                    Particles will be updated by emitter. No ordering is maintained, each emitter will spawn and update their particles in turn and sprites will be ordered
 														according to that sequence.
-	tfxParticleManagerMode_ordered_by_age                Particles will be kept in age order, older particles will be drawn first and newer ones last
-* @param double_buffer_sprites    True or False, whether the last frame of sprites is kept so that you can use to do interpolations for smoother animation
-* @param dynamic_allocation        If set to true then when the layer_max_values is hit for a layer the sprite and particle memory allocation will be grown dynamically. This can be useful when you're unsure of how
+	tfxParticleManagerMode_ordered_by_age               Particles will be kept in age order, older particles will be drawn first and newer ones last
+* @param double_buffer_sprites  True or False, whether the last frame of sprites is kept so that you can use to do interpolations for smoother animation
+* @param dynamic_allocation     If set to true then when the max_particles is hit for a layer the sprite and particle memory allocation will be grown dynamically. This can be useful when you're unsure of how
 								many particles you will need to display while developing you're game/app. Default is false.
-* @param mt_batch_size            When using multithreading you can alter the size of each batch of particles that each thread will update. The default is 2048.
+* @param mt_batch_size          When using multithreading you can alter the size of each batch of particles that each thread will update. The default is 2048.
 
 */
-tfxAPI void InitParticleManagerFor2d(tfx_particle_manager_t *pm, tfx_library_t *library, tfxU32 layer_max_values[tfxLAYERS], unsigned int effects_limit, tfx_particle_manager_mode mode, bool double_buffer_sprites, bool dynamic_allocation, bool group_sprites_by_effect, tfxU32 mt_batch_size);
+tfxAPI void InitParticleManagerFor2d(tfx_particle_manager_t *pm, tfx_library_t *library, tfxU32 max_particles, unsigned int effects_limit, tfx_particle_manager_mode mode, bool double_buffer_sprites, bool dynamic_allocation, bool group_sprites_by_effect, tfxU32 mt_batch_size);
 
 /*
 Initialise a tfx_particle_manager_t for both 2d and 3d. This just allocates buffers for both 2d and 3d anticipating that you'll be using ReconfigureParticleManager to switch between 2d/3d modes. If you want to update
 both 2d and 3d particles at the same time then just use 2 separate particle managers instead as a particle manager can only update one type of particle 2d or 3d.
-* @param pm                        A pointer to an unitialised tfx_particle_manager_t. If you want to reconfigure a particle manager for a different usage then you can call ReconfigureParticleManager.
-* @param library                A pointer to a tfx_library_t that you will be using to add all of the effects from to the particle manager.
-* @param layer_max_values        An array of unsigned ints representing the maximum amount of particles you want available for each layer. This will allocate the appropriate amount of memory ahead of time.
+* @param pm                       A pointer to an unitialised tfx_particle_manager_t. If you want to reconfigure a particle manager for a different usage then you can call ReconfigureParticleManager.
+* @param library                  A pointer to a tfx_library_t that you will be using to add all of the effects from to the particle manager.
+* @param max_particles            An array of unsigned ints representing the maximum amount of particles you want available for each layer. This will allocate the appropriate amount of memory ahead of time.
 * @param effects_limit            The maximum amount of effects and emitters that can be updated in a single frame. This will allocate the appropriate amount of memory ahead of time. Default: 1000.
-* @param mode                    The operation mode of the particle manager regarding how particles are ordered. Default value: tfxParticleManagerMode_unordered. Possible modes are:
+* @param mode                     The operation mode of the particle manager regarding how particles are ordered. Default value: tfxParticleManagerMode_unordered. Possible modes are:
 	tfxParticleManagerMode_unordered                    Particles will be updated by emitter. No ordering is maintained, each emitter will spawn and update their particles in turn and sprites will be ordered
 														according to that sequence.
-	tfxParticleManagerMode_ordered_by_age                Particles will be kept in age order, older particles will be drawn first and newer ones last
+	tfxParticleManagerMode_ordered_by_age               Particles will be kept in age order, older particles will be drawn first and newer ones last
 * @param double_buffer_sprites    True or False, whether the last frame of sprites is kept so that you can use to do interpolations for smoother animation
-* @param dynamic_allocation        If set to true then when the layer_max_values is hit for a layer the sprite and particle memory allocation will be grown dynamically. This can be useful when you're unsure of how
-								many particles you will need to display while developing you're game/app. Default is false.
+* @param dynamic_allocation       If set to true then when the max_particles is hit for a layer the sprite and particle memory allocation will be grown dynamically. This can be useful when you're unsure of how
+								  many particles you will need to display while developing you're game/app. Default is false.
 * @param mt_batch_size            When using multithreading you can alter the size of each batch of particles that each thread will update. The default is 2048.
 
 */
-tfxAPI void InitParticleManagerForBoth(tfx_particle_manager_t *pm, tfx_library_t *library, tfxU32 layer_max_values[tfxLAYERS], unsigned int effects_limit, tfx_particle_manager_mode mode, bool double_buffer_sprites, bool dynamic_sprite_allocation, bool group_sprites_by_effect, tfxU32 multi_threaded_batch_size);
+tfxAPI void InitParticleManagerForBoth(tfx_particle_manager_t *pm, tfx_library_t *library, tfxU32 max_particles, unsigned int effects_limit, tfx_particle_manager_mode mode, bool double_buffer_sprites, bool dynamic_sprite_allocation, bool group_sprites_by_effect, tfxU32 multi_threaded_batch_size);
 
 /*
 Reconfigure a particle manager to make it work in a different mode. A particle manager can only run in a single mode at time like unordered, depth ordered etc so use this to change that. Also bear
 in mind that you can just use more than one particle manager and utilised different modes that way as well. The modes that you need will depend on the effects that you're adding to the particle manager.
-* @param pm                        A pointer to an intialised tfx_particle_manager_t.
-* @param mode                    One of the following modes:
-								tfxParticleManagerMode_unordered
-								tfxParticleManagerMode_ordered_by_age
-								tfxParticleManagerMode_ordered_by_depth
-								tfxParticleManagerMode_ordered_by_depth_guaranteed
-* @param sort_passes            The number of sort passes if you're using depth sorted effects
+* @param pm                       A pointer to an intialised tfx_particle_manager_t.
+* @param mode                     One of the following modes:
+								  tfxParticleManagerMode_unordered
+								  tfxParticleManagerMode_ordered_by_age
+								  tfxParticleManagerMode_ordered_by_depth
+								  tfxParticleManagerMode_ordered_by_depth_guaranteed
+* @param sort_passes              The number of sort passes if you're using depth sorted effects
 * @param is_3d                    True if the particle manager should be configured for 3d effects.
 */
 tfxAPI void ReconfigureParticleManager(tfx_particle_manager_t *pm, tfx_particle_manager_mode mode, tfxU32 sort_passes, bool is_3d);
@@ -7590,7 +7590,7 @@ tfxAPI void ReconfigureParticleManager(tfx_particle_manager_t *pm, tfx_particle_
 /*
 Turn on and off whether the particle manager should sort the effects by depth order. Use SetPMCamera to set the position of the camera that the particle manager will
 use to update the depth of each effect in the scene (3d mode). In 2d mode the depth will be auto set to the y position of the effect.
-* @param pm                        A pointer to an intialised tfx_particle_manager_t.
+* @param pm                       A pointer to an intialised tfx_particle_manager_t.
 * @param yesno                    A boolean, set to true or false if you want auto ordering on or off respectively
 */
 tfxAPI inline void TogglePMOrderEffects(tfx_particle_manager_t *pm, bool yesno) {
@@ -7731,7 +7731,7 @@ Get the total number of 3d sprites ready for rendering in the particle manager
 * @param pm                    A pointer to an initialised tfx_particle_manager_t.
 */
 tfxAPI inline tfxU32 TotalSpriteCount(tfx_particle_manager_t *pm) {
-	return pm->instance_buffer[pm->current_sprite_buffer].current_size;
+	return pm->instance_buffer.current_size;
 }
 
 /*
@@ -7849,7 +7849,7 @@ Get the transform vectors for a 3d sprite's previous position so that you can us
 * @param index            The sprite index of the sprite that you want the captured sprite for.
 */
 tfxAPI inline tfx_vec3_t GetCapturedSprite3dTransform(tfx_particle_manager_t *pm, tfxU32 layer, tfxU32 index) {
-	return static_cast<tfx_billboard_instance_t*>(pm->instance_buffer[(index & 0x40000000) >> 30].data)[index & 0x0FFFFFFF].position.xyz();
+	return static_cast<tfx_billboard_instance_t*>(pm->instance_buffer.data)[index & 0x0FFFFFFF].position.xyz();
 }
 
 /*
@@ -7859,7 +7859,7 @@ Get the transform vectors for a 2d sprite's previous position so that you can us
 * @param index            The sprite index of the sprite that you want the captured sprite for.
 */
 tfxAPI inline tfx_vec2_t GetCapturedSprite2dTransform(tfx_particle_manager_t *pm, tfxU32 layer, tfxU32 index) {
-	return static_cast<tfx_sprite_instance_t*>(pm->instance_buffer[(index & 0x40000000) >> 30].data)[index & 0x0FFFFFFF].position.xy();
+	return static_cast<tfx_sprite_instance_t*>(pm->instance_buffer.data)[index & 0x0FFFFFFF].position.xy();
 }
 
 /*

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -6879,6 +6879,13 @@ inline void InvalidateNewSpriteCapturedIndex(T* instance, tfx_vector_t<tfx_uniqu
 	}
 }
 
+template<typename T>
+inline void InvalidateOffsettedSpriteCapturedIndex(T* instance, tfx_vector_t<tfx_unique_sprite_id_t> &uids, tfx_particle_manager_t *pm, tfxU32 layer) {
+	for (tfxU32 i = 0; i != pm->instance_buffer_for_recording[pm->current_sprite_buffer][layer].current_size; ++i) {
+		instance[i].captured_index = tfxINVALID;
+	}
+}
+
 tfxINTERNAL float GetEmissionDirection2d(tfx_particle_manager_t *pm, tfx_library_t *library, tfx_random_t *random, tfx_emitter_state_t &emitter, tfx_vec2_t local_position, tfx_vec2_t world_position);
 tfxINTERNAL tfx_vec3_t RandomVectorInCone(tfx_random_t *random, tfx_vec3_t cone_direction, float cone_angle);
 tfxINTERNAL void RandomVectorInConeWide(tfxWideInt seed, tfxWideFloat dx, tfxWideFloat dy, tfxWideFloat dz, tfxWideFloat cone_angle, tfxWideFloat *result_x, tfxWideFloat *result_y, tfxWideFloat *result_z);

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -7028,7 +7028,7 @@ tfxAPI_EDITOR void CompileLibraryEmitterGraphs(tfx_library_t *library, tfxU32 in
 tfxAPI_EDITOR void CompileLibraryPropertyGraph(tfx_library_t *library, tfxU32 index);
 tfxAPI_EDITOR void CompileLibraryBaseGraph(tfx_library_t *library, tfxU32 index);
 tfxAPI_EDITOR void CompileLibraryVariationGraph(tfx_library_t *library, tfxU32 index);
-tfxAPI_EDITOR void CompileLibraryOvertimeGraph(tfx_library_t *library, tfxU32 index, bool including_color_graphs = true);
+tfxAPI_EDITOR void CompileLibraryOvertimeGraph(tfx_library_t *library, tfxU32 index, bool including_color_ramps = true);
 tfxAPI_EDITOR void CompileLibraryFactorGraph(tfx_library_t *library, tfxU32 index);
 tfxAPI_EDITOR void CompileLibraryColorGraphs(tfx_library_t *library, tfxU32 index);
 tfxAPI_EDITOR void CompileLibraryGraphsOfEffect(tfx_library_t *library, tfx_effect_emitter_t *effect, tfxU32 depth = 0);

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -6724,12 +6724,12 @@ inline void WriteParticleColorSpriteDataOrdered(T *sprites, tfx_particle_manager
 }
 
 template<typename T>
-inline void WriteParticleImageSpriteData(T *sprites, tfx_particle_manager_t &pm, tfxU32 layer, tfxU32 start_diff, tfxU32 limit_index, tfx_particle_soa_t &bank, tfxWideArrayi &flags, tfxWideArrayi &image_indexes, const tfxEmitterStateFlags emitter_flags, const tfx_billboarding_option billboard_option, tfxU32 index, tfxU32 &running_sprite_index) {
+inline void WriteParticleImageSpriteData(T *sprites, tfx_particle_manager_t &pm, tfxU32 layer, tfxU32 start_diff, tfxU32 limit_index, tfx_particle_soa_t &bank, tfxWideArrayi &flags, tfxWideArrayi &image_indexes, const tfxEmitterStateFlags emitter_flags, const tfx_billboarding_option billboard_option, tfxU32 index, tfxU32 &running_sprite_index, tfxU32 captured_offset) {
 	for (tfxU32 j = start_diff; j < tfxMin(limit_index + start_diff, tfxDataWidth); ++j) {
 		int index_j = index + j;
 		tfxU32 &sprites_index = bank.sprite_index[index_j];
 		tfxU32 capture = flags.a[j];
-		sprites[running_sprite_index].captured_index = capture == 0 ? (pm.current_sprite_buffer << 30) + running_sprite_index : (!pm.current_sprite_buffer << 30) + (sprites_index & 0x0FFFFFFF);
+		sprites[running_sprite_index].captured_index = capture == 0 ? (pm.current_sprite_buffer << 30) + running_sprite_index + captured_offset : (!pm.current_sprite_buffer << 30) + (sprites_index & 0x0FFFFFFF);
 		sprites[running_sprite_index].captured_index |= emitter_flags & tfxEmitterStateFlags_wrap_single_sprite ? 0x80000000 : 0;
 		sprites_index = layer + running_sprite_index;
 		sprites[running_sprite_index].indexes = image_indexes.a[j];
@@ -6740,13 +6740,13 @@ inline void WriteParticleImageSpriteData(T *sprites, tfx_particle_manager_t &pm,
 }
 
 template<typename T>
-inline void WriteParticleImageSpriteDataOrdered(T *sprites, tfx_particle_manager_t &pm, tfxU32 layer, tfxU32 start_diff, tfxU32 limit_index, tfx_particle_soa_t &bank, tfxWideArrayi &flags, tfxWideArrayi &image_indexes, const tfxEmitterStateFlags emitter_flags, const tfx_billboarding_option billboard_option, tfxU32 index, tfxU32 &running_sprite_index) {
+inline void WriteParticleImageSpriteDataOrdered(T *sprites, tfx_particle_manager_t &pm, tfxU32 layer, tfxU32 start_diff, tfxU32 limit_index, tfx_particle_soa_t &bank, tfxWideArrayi &flags, tfxWideArrayi &image_indexes, const tfxEmitterStateFlags emitter_flags, const tfx_billboarding_option billboard_option, tfxU32 index, tfxU32 &running_sprite_index, tfxU32 captured_offset) {
 	for (tfxU32 j = start_diff; j < tfxMin(limit_index + start_diff, tfxDataWidth); ++j) {
 		int index_j = index + j;
 		tfxU32 sprite_depth_index = bank.depth_index[index_j] + pm.cumulative_index_point[layer >> 28];
 		tfxU32 &sprites_index = bank.sprite_index[index_j];
 		tfxU32 capture = flags.a[j];
-		sprites[sprite_depth_index].captured_index = capture == 0 && bank.single_loop_count[index_j] == 0 ? (pm.current_sprite_buffer << 30) + sprite_depth_index : (!pm.current_sprite_buffer << 30) + (sprites_index & 0x0FFFFFFF);
+		sprites[sprite_depth_index].captured_index = capture == 0 && bank.single_loop_count[index_j] == 0 ? (pm.current_sprite_buffer << 30) + sprite_depth_index + captured_offset : (!pm.current_sprite_buffer << 30) + (sprites_index & 0x0FFFFFFF);
 		sprites[sprite_depth_index].captured_index |= emitter_flags & tfxEmitterStateFlags_wrap_single_sprite ? 0x80000000 : 0;
 		sprites_index = layer + sprite_depth_index;
 		sprites[sprite_depth_index].indexes = image_indexes.a[j];

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -8042,6 +8042,11 @@ You can use this function to get each billboard buffer for every effect that is 
 */
 tfxAPI bool GetNextBillboardBuffer(tfx_particle_manager_t *pm, tfx_billboard_instance_t **sprites_soa, tfx_effect_instance_data_t **effect_sprites, tfxU32 *sprite_count);
 
+/*After calling GetNextBillboard/SpriteBuffer in a while loop you can call this to reset the index for the next frame
+* @param pm						A pointer to a tfx_particle_manager_t
+*/
+tfxAPI bool ResetInstanceBufferLoopIndex(tfx_particle_manager_t *pm);
+
 /*
 Set the rotation of a 2d effect
 * @param pm                A pointer to a tfx_particle_manager_t where the effect is being managed. Note that this must be called after UpdateParticleManager in order to override the current rotation of the effect that was

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -7053,6 +7053,7 @@ tfxAPI_EDITOR void tfxFreeBitmap(tfx_bitmap_t *bitmap);
 tfxAPI_EDITOR void PlotColorRamp(tfx_bitmap_t *bitmap, tfx_color_ramp_t *ramp, tfxU32 y);
 tfxAPI_EDITOR void CreateColorRampBitmaps(tfx_library_t *library);
 tfxAPI_EDITOR void EditColorRampBitmap(tfx_library_t *library, tfx_overtime_attributes_t *a, tfxU32 ramp_id);
+tfxAPI_EDITOR void MaybeInsertColorRampBitmap(tfx_library_t *library, tfx_overtime_attributes_t *a, tfxU32 ramp_id);
 tfxAPI_EDITOR tfxU32 AddColorRampToBitmaps(tfx_library_t *library, tfx_color_ramp_t *ramp);
 tfxAPI_EDITOR float GetMaxLife(tfx_effect_emitter_t *e);
 tfxAPI_EDITOR float LookupFastOvertime(tfx_graph_t *graph, float age, float lifetime);

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -7573,6 +7573,23 @@ tfxAPI inline void TogglePMOrderEffects(tfx_particle_manager_t *pm, bool yesno) 
 }
 
 /*
+Get the sprite buffer in the particle manager containing all the 2d sprites that were created the last frame. You can use this to copy to a staging buffer to upload to the gpu.
+This will be a pointer to the start of the buffer for uploading all the sprites. If you want to do this for each effect then you can call GetEffectSpriteBuffer.
+* @param pm                       A pointer to an intialised tfx_particle_manager_t.
+*/
+tfxAPI inline tfx_sprite_instance_t *GetSpriteBuffer(tfx_particle_manager_t *pm) {
+	return tfxCastBufferRef(tfx_sprite_instance_t, pm->instance_buffer);
+}
+
+/*
+Get the billboard buffer in the particle manager containing all the 3d billboards that were created the last frame. You can use this to copy to a staging buffer to upload to the gpu.
+* @param pm                       A pointer to an intialised tfx_particle_manager_t.
+*/
+tfxAPI inline tfx_billboard_instance_t *GetBillboardBuffer(tfx_particle_manager_t *pm) {
+	return tfxCastBufferRef(tfx_billboard_instance_t, pm->instance_buffer);
+}
+
+/*
 When a particle manager updates particles it creates work queues to handle the work. By default these each have a maximum amount of 1000 entries which should be
 more than enough for most situations. However you can increase the sizes here if needed. You only need to set this manually if you hit one of the asserts when these
 run out of space or you anticipate a huge amount of emitters and particles to be used (> million). On the other hand, you might be tight on memory in which case you

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -6145,6 +6145,7 @@ struct tfx_particle_manager_t {
 	tfx_sprite_soa_t sprites[2][tfxLAYERS];
 	tfx_buffer_t instance_buffer[2];
 	tfxU32 current_sprite_buffer;
+	tfxU32 highest_depth_index;
 
 	//todo: document compute controllers once we've established this is how we'll be doing it.
 	void *compute_controller_ptr;
@@ -6195,6 +6196,10 @@ struct tfx_particle_manager_t {
 	tfxParticleManagerFlags flags;
 	//The length of time that passed since the last time Update() was called
 	float frame_length;
+	//You can cap the frame length to a maximum amount which I put in mainly for when stepping through 
+	//with a debugger and you don't want to advance the particles too much because obviously a lot of
+	//time is passing between frames because you're stepping through the code. Default is 240ms.
+	float max_frame_length;
 	tfxWideFloat frame_length_wide;
 	float update_time;
 	tfxWideFloat update_time_wide;
@@ -6217,7 +6222,8 @@ struct tfx_particle_manager_t {
 		current_sprite_buffer(0),
 		free_compute_controllers(tfxCONSTRUCTOR_VEC_INIT(pm "free_compute_controllers")),
 		library(nullptr),
-		sort_passes(0)
+		sort_passes(0),
+		max_frame_length(240.f)
 	{
 	}
 	~tfx_particle_manager_t();

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -6718,9 +6718,9 @@ inline void WriteParticleColorSpriteData(T *sprites, tfxU32 start_diff, tfxU32 l
 }
 
 template<typename T>
-inline void WriteParticleColorSpriteDataOrdered(T *sprites, tfx_particle_manager_t &pm, tfxU32 layer, tfxU32 start_diff, tfxU32 limit_index, const tfxU32 *depth_index, tfxU32 index, const tfxWideArrayi &packed_intensity_life, const tfxWideArrayi &curved_alpha, tfxU32 &running_sprite_index) {
+inline void WriteParticleColorSpriteDataOrdered(T *sprites, tfx_particle_manager_t &pm, tfxU32 layer, tfxU32 start_diff, tfxU32 limit_index, const tfxU32 *depth_index, tfxU32 index, const tfxWideArrayi &packed_intensity_life, const tfxWideArrayi &curved_alpha, tfxU32 &running_sprite_index, tfxU32 captured_offset) {
 	for (tfxU32 j = start_diff; j < tfxMin(limit_index + start_diff, tfxDataWidth); ++j) {
-		tfxU32 sprite_depth_index = depth_index[index + j] + pm.cumulative_index_point[layer];
+		tfxU32 sprite_depth_index = depth_index[index + j] + pm.cumulative_index_point[layer] + captured_offset;
 		sprites[sprite_depth_index].intensity_life.packed = packed_intensity_life.a[j];
 		sprites[sprite_depth_index].curved_alpha.packed = curved_alpha.a[j];
 		running_sprite_index++;
@@ -6728,7 +6728,7 @@ inline void WriteParticleColorSpriteDataOrdered(T *sprites, tfx_particle_manager
 }
 
 template<typename T>
-inline void WriteParticleImageSpriteData(T *sprites, tfx_particle_manager_t &pm, tfxU32 layer, tfxU32 start_diff, tfxU32 limit_index, tfx_particle_soa_t &bank, tfxWideArrayi &flags, tfxWideArrayi &image_indexes, const tfxEmitterStateFlags emitter_flags, const tfx_billboarding_option billboard_option, tfxU32 index, tfxU32 &running_sprite_index, tfxU32 captured_offset) {
+inline void WriteParticleImageSpriteData(T *sprites, tfx_particle_manager_t &pm, tfxU32 layer, tfxU32 start_diff, tfxU32 limit_index, tfx_particle_soa_t &bank, tfxWideArrayi &flags, tfxWideArrayi &image_indexes, const tfxEmitterStateFlags emitter_flags, const tfx_billboarding_option billboard_option, tfxU32 index, tfxU32 &running_sprite_index) {
 	for (tfxU32 j = start_diff; j < tfxMin(limit_index + start_diff, tfxDataWidth); ++j) {
 		int index_j = index + j;
 		tfxU32 &sprites_index = bank.sprite_index[index_j];
@@ -6747,7 +6747,7 @@ template<typename T>
 inline void WriteParticleImageSpriteDataOrdered(T *sprites, tfx_particle_manager_t &pm, tfxU32 layer, tfxU32 start_diff, tfxU32 limit_index, tfx_particle_soa_t &bank, tfxWideArrayi &flags, tfxWideArrayi &image_indexes, const tfxEmitterStateFlags emitter_flags, const tfx_billboarding_option billboard_option, tfxU32 index, tfxU32 &running_sprite_index, tfxU32 captured_offset) {
 	for (tfxU32 j = start_diff; j < tfxMin(limit_index + start_diff, tfxDataWidth); ++j) {
 		int index_j = index + j;
-		tfxU32 sprite_depth_index = bank.depth_index[index_j] + pm.cumulative_index_point[layer >> 28];
+		tfxU32 sprite_depth_index = bank.depth_index[index_j] + pm.cumulative_index_point[layer >> 28] + captured_offset;
 		tfxU32 &sprites_index = bank.sprite_index[index_j];
 		tfxU32 capture = flags.a[j];
 		sprites[sprite_depth_index].captured_index = capture == 0 && bank.single_loop_count[index_j] == 0 ? (pm.current_sprite_buffer << 30) + sprite_depth_index : (!pm.current_sprite_buffer << 30) + (sprites_index & 0x0FFFFFFF);

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -5717,7 +5717,7 @@ struct tfx_sprite_instance_t {						//44 bytes
 	tfxU32 alignment;								//normalised alignment vector 2 floats packed into 16bits or 3 8bit floats for 3d
 	tfxU32 intensity_life;							//Multiplier for the color and life of particle
 	tfxU32 curved_alpha;							//Sharpness and dissolve amount value for fading the image
-	tfxU32 indexes;									//[color ramp y index, color ramp texture array index, capture flag (1 bit << 15), billboard alignment (2 bits << 13), image data index max 8191 images]
+	tfxU32 indexes;									//[color ramp y index, color ramp texture array index, capture flag, image data index (1 bit << 15), billboard alignment (2 bits << 13), image data index max 8191 images]
 	tfxU32 captured_index;							//Index to the sprite in the buffer from the previous frame for interpolation
 	tfxU32 uid;
 };
@@ -5729,7 +5729,7 @@ struct tfx_billboard_instance_t {					//56 bytes
 	tfxU64 size_handle;								//Size of the sprite in pixels and the handle packed into a u64 (4 16bit floats)
 	tfxU32 intensity_life;							//Multiplier for the color and life of particle
 	tfxU32 curved_alpha;							//Sharpness and dissolve amount value for fading the image
-	tfxU32 indexes;									//[color ramp y index, color ramp texture array index, capture flag (1 bit << 15), billboard alignment (2 bits << 13), image data index max 8191 images]
+	tfxU32 indexes;									//[color ramp y index, color ramp texture array index, capture flag, image data index (1 bit << 15), billboard alignment (2 bits << 13), image data index max 8191 images]
 	tfxU32 captured_index;							//Index to the sprite in the buffer from the previous frame for interpolation
 };
 
@@ -5886,6 +5886,7 @@ struct alignas(16) tfx_gpu_image_data_t {
 	tfx_vec2_t image_size;
 	tfxU32 texture_array_index;
 	float animation_frames;
+	float max_radius;
 #ifdef tfxCUSTOM_GPU_IMAGE_DATA
 	//add addition image data if needed
 #endif
@@ -6171,6 +6172,7 @@ struct tfx_particle_manager_t {
 
 	tfxU32 sprite_index_point[tfxLAYERS];
 	tfxU32 cumulative_index_point[tfxLAYERS];
+	tfxU32 layer_sizes[tfxLAYERS];
 
 	int mt_batch_size;
 	std::mutex particle_index_mutex;
@@ -6535,6 +6537,7 @@ tfxAPI_EDITOR tfxU32 Pack8bitQuaternion(tfx_quaternion_t v);
 tfxAPI_EDITOR tfxU32 Pack16bitUnsigned(float x, float y);
 tfxAPI_EDITOR tfx_vec2_t UnPack16bit(tfxU32 in);
 tfxINTERNAL tfx_vec2_t UnPack16bitUnsigned(tfxU32 in);
+tfxAPI_EDITOR tfx_vec2_t UnPack16bit2SScaled(tfxU32 value, float max_value);
 tfxINTERNAL tfxWideInt PackWide16bitStretch(tfxWideFloat &v_x, tfxWideFloat &v_y);
 tfxAPI_EDITOR tfxWideInt PackWide16bit(tfxWideFloat &v_x, tfxWideFloat &v_y);
 tfxAPI_EDITOR tfxWideInt PackWide16bit2SScaled(tfxWideFloat v_x, tfxWideFloat  v_y, float max_value);

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -6738,18 +6738,13 @@ inline void SpriteDataOffsetCapturedIndexes(T* instance, tfx_sprite_data_t *spri
 			if (instance[j].captured_index == tfxINVALID) continue;
 			tfxU32 wrap_bit = instance[j].captured_index & 0x80000000;
 			instance[j].captured_index = (instance[j].captured_index & 0x0FFFFFFF) + sprite_data->normal.frame_meta[previous_frame].index_offset[layer];
-			if (sprite_data->real_time_sprites.uid[instance[j].captured_index].uid != sprite_data->real_time_sprites.uid[j].uid) {
-				//tfxPrint("%i) %u, %u, %u, %u, %u, %u", j, instance[j].captured_index, sprite_data->real_time_sprites.uid[instance[j].captured_index].uid, sprite_data->real_time_sprites.uid[instance[j].captured_index].age, sprite_data->real_time_sprites.uid[j].uid, sprite_data->real_time_sprites.uid[j].age, sprite_data->normal.frame_meta[previous_frame].captured_offset);
-			}
-			//TFX_ASSERT(sprite_data->real_time_sprites.uid[instance[j].captured_index].uid == sprite_data->real_time_sprites.uid[j].uid);
+			TFX_ASSERT(sprite_data->real_time_sprites.uid[instance[j].captured_index].uid == sprite_data->real_time_sprites.uid[j].uid);
 			instance[j].captured_index |= wrap_bit;
 		}
 		if (layer > 0) {
 			layer_offset += sprite_data->normal.frame_meta[previous_frame].cumulative_offset[layer];
 		}
-		//tfxPrint("--------- %i - %i ------------", current_frame, layer);
 	}
-	//tfxPrint("************* end of frame %i ****************", current_frame);
 }
 
 template<typename T>

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -6722,9 +6722,9 @@ inline void WriteParticleColorSpriteData(T *sprites, tfxU32 start_diff, tfxU32 l
 }
 
 template<typename T>
-inline void WriteParticleColorSpriteDataOrdered(T *sprites, tfx_particle_manager_t &pm, tfxU32 layer, tfxU32 start_diff, tfxU32 limit_index, const tfxU32 *depth_index, tfxU32 index, const tfxWideArrayi &packed_intensity_life, const tfxWideArrayi &curved_alpha, tfxU32 &running_sprite_index, tfxU32 captured_offset) {
+inline void WriteParticleColorSpriteDataOrdered(T *sprites, tfx_particle_manager_t &pm, tfxU32 layer, tfxU32 start_diff, tfxU32 limit_index, const tfxU32 *depth_index, tfxU32 index, const tfxWideArrayi &packed_intensity_life, const tfxWideArrayi &curved_alpha, tfxU32 &running_sprite_index, tfxU32 instance_offset) {
 	for (tfxU32 j = start_diff; j < tfxMin(limit_index + start_diff, tfxDataWidth); ++j) {
-		tfxU32 sprite_depth_index = depth_index[index + j] + pm.cumulative_index_point[layer] + captured_offset;
+		tfxU32 sprite_depth_index = depth_index[index + j] + instance_offset;
 		sprites[sprite_depth_index].intensity_life.packed = packed_intensity_life.a[j];
 		sprites[sprite_depth_index].curved_alpha.packed = curved_alpha.a[j];
 		running_sprite_index++;
@@ -6748,10 +6748,10 @@ inline void WriteParticleImageSpriteData(T *sprites, tfx_particle_manager_t &pm,
 }
 
 template<typename T>
-inline void WriteParticleImageSpriteDataOrdered(T *sprites, tfx_particle_manager_t &pm, tfxU32 layer, tfxU32 start_diff, tfxU32 limit_index, tfx_particle_soa_t &bank, tfxWideArrayi &flags, tfxWideArrayi &image_indexes, const tfxEmitterStateFlags emitter_flags, const tfx_billboarding_option billboard_option, tfxU32 index, tfxU32 &running_sprite_index, tfxU32 captured_offset) {
+inline void WriteParticleImageSpriteDataOrdered(T *sprites, tfx_particle_manager_t &pm, tfxU32 layer, tfxU32 start_diff, tfxU32 limit_index, tfx_particle_soa_t &bank, tfxWideArrayi &flags, tfxWideArrayi &image_indexes, const tfxEmitterStateFlags emitter_flags, const tfx_billboarding_option billboard_option, tfxU32 index, tfxU32 &running_sprite_index, tfxU32 instance_offset) {
 	for (tfxU32 j = start_diff; j < tfxMin(limit_index + start_diff, tfxDataWidth); ++j) {
 		int index_j = index + j;
-		tfxU32 sprite_depth_index = bank.depth_index[index_j] + pm.cumulative_index_point[layer >> 28] + captured_offset;
+		tfxU32 sprite_depth_index = bank.depth_index[index_j] + instance_offset;
 		tfxU32 &sprites_index = bank.sprite_index[index_j];
 		tfxU32 capture = flags.a[j];
 		sprites[sprite_depth_index].captured_index = capture == 0 && bank.single_loop_count[index_j] == 0 ? (pm.current_sprite_buffer << 30) + sprite_depth_index : (!pm.current_sprite_buffer << 30) + (sprites_index & 0x0FFFFFFF);

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -3110,6 +3110,8 @@ struct tfx_vector_t {
 #define tfxCastBuffer(type, buffer) static_cast<type*>(buffer->data)
 #define tfxCastBufferRef(type, buffer) static_cast<type*>(buffer.data)
 
+//This simple container struct was created for storing sprites in the particle manager. I didn't want this templated because either 2d or 3d sprites could be used so
+//I wanted to cast as needed when writing and using the sprite data. See simple cast macros above tfxCastBuffer and tfxCastBufferRef
 struct tfx_buffer_t {
 	tfxU32 current_size;
 	tfxU32 capacity;
@@ -6676,7 +6678,7 @@ inline void WriteParticleImageSpriteData(T *sprites, tfx_particle_manager_t &pm,
 		tfxU32 capture = flags.a[j];
 		sprites[running_sprite_index].captured_index = capture == 0 ? (pm.current_sprite_buffer << 30) + running_sprite_index : (!pm.current_sprite_buffer << 30) + (sprites_index & 0x0FFFFFFF);
 		sprites[running_sprite_index].captured_index |= emitter_flags & tfxEmitterStateFlags_wrap_single_sprite ? 0x80000000 : 0;
-		sprites_index = running_sprite_index;
+		sprites_index = layer + running_sprite_index;
 		sprites[running_sprite_index].indexes = image_indexes.a[j];
 		sprites[running_sprite_index].indexes |= (billboard_option << 13) | capture;
 		bank.flags[index_j] &= ~tfxParticleFlags_capture_after_transform;

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -7217,7 +7217,7 @@ tfxINTERNAL tfx_compute_particle_t *GrabComputeParticle(tfx_particle_manager_t *
 tfxINTERNAL void ResetParticlePtr(tfx_particle_manager_t *pm, void *ptr);
 tfxINTERNAL void ResetControllerPtr(tfx_particle_manager_t *pm, void *ptr);
 tfxINTERNAL void UpdateCompute(tfx_particle_manager_t *pm, void *sampled_particles, unsigned int sample_size = 100);
-tfxINTERNAL void InitCommonParticleManager(tfx_particle_manager_t *pm, tfx_library_t *library, tfxU32 max_particles[tfxLAYERS], unsigned int effects_limit, tfx_particle_manager_mode mode, bool double_buffered_sprites, bool dynamic_sprite_allocation, bool group_sprites_by_effect, tfxU32 mt_batch_size);
+tfxINTERNAL void InitCommonParticleManager(tfx_particle_manager_t *pm, tfx_library_t *library, tfxU32 max_particles, unsigned int effects_limit, tfx_particle_manager_mode mode, bool double_buffered_sprites, bool dynamic_sprite_allocation, bool group_sprites_by_effect, tfxU32 mt_batch_size);
 tfxINTERNAL bool ValidEffectID(tfx_particle_manager_t *pm, tfxEffectID id);
 
 //--------------------------------

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -7742,8 +7742,8 @@ Get the transform vectors for a 2d sprite's previous position so that you can us
 * @param layer            The index of the sprite layer
 * @param index            The sprite index of the sprite that you want the captured sprite for.
 */
-tfxAPI inline tfx_sprite_transform2d_t *GetCapturedSprite2dTransform(tfx_particle_manager_t *pm, tfxU32 layer, tfxU32 index) {
-	return &pm->sprites[(index & 0x40000000) >> 30][layer].transform_2d[index & 0x0FFFFFFF];
+tfxAPI inline tfx_vec2_t GetCapturedSprite2dTransform(tfx_particle_manager_t *pm, tfxU32 layer, tfxU32 index) {
+	return static_cast<tfx_sprite_instance_t*>(pm->instance_buffer[(index & 0x40000000) >> 30][layer].data)[index & 0x0FFFFFFF].position_stretch_rotation.xy();
 }
 
 /*

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -2349,24 +2349,25 @@ enum tfx_effect_library_stream_context : tfxU32 {
 	tfxEndFrameOffsets,
 };
 
-typedef tfxU32 tfxEmitterPropertyFlags;            //tfx_emitter_property_flag_bits
-typedef tfxU32 tfxEffectPropertyFlags;            //tfx_effect_property_flag_bits
-typedef tfxU32 tfxVectorFieldFlags;                //tfx_vector_field_flag_bits
+typedef tfxU32 tfxEmitterPropertyFlags;         //tfx_emitter_property_flag_bits
+typedef tfxU32 tfxColorRampFlags;		        //tfx_color_ramp_flag_bits
+typedef tfxU32 tfxEffectPropertyFlags;          //tfx_effect_property_flag_bits
+typedef tfxU32 tfxVectorFieldFlags;             //tfx_vector_field_flag_bits
 typedef tfxU32 tfxParticleFlags;                //tfx_particle_flag_bits
 typedef tfxU32 tfxEmitterStateFlags;            //tfx_emitter_state_flag_bits
-typedef tfxU32 tfxEffectStateFlags;                //tfx_effect_state_flag_bits
-typedef tfxU32 tfxParticleControlFlags;            //tfx_particle_control_flag_bits
-typedef tfxU32 tfxAttributeNodeFlags;            //tfx_attribute_node_flag_bits
+typedef tfxU32 tfxEffectStateFlags;             //tfx_effect_state_flag_bits
+typedef tfxU32 tfxParticleControlFlags;         //tfx_particle_control_flag_bits
+typedef tfxU32 tfxAttributeNodeFlags;           //tfx_attribute_node_flag_bits
 typedef tfxU32 tfxAngleSettingFlags;            //tfx_angle_setting_flag_bits
-typedef tfxU32 tfxParticleManagerFlags;            //tfx_particle_manager_flag_bits
-typedef tfxU32 tfxErrorFlags;                    //tfx_error_flag_bits
-typedef tfxU32 tfxEffectCloningFlags;            //tfx_effect_cloning_flag_bits
-typedef tfxU32 tfxAnimationFlags;                //tfx_animation_flag_bits
-typedef tfxU32 tfxAnimationInstanceFlags;        //tfx_animation_instance_flag_bits
+typedef tfxU32 tfxParticleManagerFlags;         //tfx_particle_manager_flag_bits
+typedef tfxU32 tfxErrorFlags;                   //tfx_error_flag_bits
+typedef tfxU32 tfxEffectCloningFlags;           //tfx_effect_cloning_flag_bits
+typedef tfxU32 tfxAnimationFlags;               //tfx_animation_flag_bits
+typedef tfxU32 tfxAnimationInstanceFlags;       //tfx_animation_instance_flag_bits
 typedef tfxU32 tfxAnimationManagerFlags;        //tfx_animation_manager_flag_bits
-typedef tfxU32 tfxEmitterPathFlags;                //tfx_emitter_path_flag_bits
-typedef tfxU32 tfxEmitterControlProfileFlags;    //tfx_emitter_control_profile_flag_bits
-typedef tfxU32 tfxPackageFlags;                    //tfx_package_flag_bits
+typedef tfxU32 tfxEmitterPathFlags;             //tfx_emitter_path_flag_bits
+typedef tfxU32 tfxEmitterControlProfileFlags;   //tfx_emitter_control_profile_flag_bits
+typedef tfxU32 tfxPackageFlags;                 //tfx_package_flag_bits
 
 enum tfx_error_flag_bits {
 	tfxErrorCode_success = 0,
@@ -2546,66 +2547,71 @@ enum tfx_effect_property_flag_bits {
 
 enum tfx_emitter_property_flag_bits {
 	tfxEmitterPropertyFlags_none = 0,
-	tfxEmitterPropertyFlags_random_color = 1 << 0,                        //Pick a random color from the color overtime gradient rather then change the color over the lifetime of the particle
-	tfxEmitterPropertyFlags_relative_position = 1 << 1,                    //Keep the particles position relative to the current position of the emitter
+	tfxEmitterPropertyFlags_random_color = 1 << 0,                      //Pick a random color from the color overtime gradient rather then change the color over the lifetime of the particle
+	tfxEmitterPropertyFlags_relative_position = 1 << 1,                 //Keep the particles position relative to the current position of the emitter
 	tfxEmitterPropertyFlags_relative_angle = 1 << 2,                    //Keep the angle of the particles relative to the current angle of the emitter
-	tfxEmitterPropertyFlags_image_handle_auto_center = 1 << 3,            //Set the offset of the particle to the center of the image
+	tfxEmitterPropertyFlags_image_handle_auto_center = 1 << 3,          //Set the offset of the particle to the center of the image
 	tfxEmitterPropertyFlags_single = 1 << 4,                            //Only spawn a single particle (or number of particles specified by spawn_amount) that does not expire
-	tfxEmitterPropertyFlags_spawn_on_grid = 1 << 5,                        //When using an area, line or ellipse emitter, spawn along a grid
-	tfxEmitterPropertyFlags_grid_spawn_clockwise = 1 << 6,                //Spawn clockwise/left to right around the area
-	tfxEmitterPropertyFlags_fill_area = 1 << 7,                            //Fill the area
+	tfxEmitterPropertyFlags_spawn_on_grid = 1 << 5,                     //When using an area, line or ellipse emitter, spawn along a grid
+	tfxEmitterPropertyFlags_grid_spawn_clockwise = 1 << 6,              //Spawn clockwise/left to right around the area
+	tfxEmitterPropertyFlags_fill_area = 1 << 7,                         //Fill the area
 	tfxEmitterPropertyFlags_emitter_handle_auto_center = 1 << 8,        //Center the handle of the emitter
 	tfxEmitterPropertyFlags_edge_traversal = 1 << 9,                    //Line and Path emitters only: make particles traverse the line/path
 	tfxEmitterPropertyFlags_base_uniform_size = 1 << 10,                //Keep the base particle size uniform
 	tfxEmitterPropertyFlags_lifetime_uniform_size = 1 << 11,            //Keep the size over lifetime of the particle uniform
-	tfxEmitterPropertyFlags_animate = 1 << 12,                            //Animate the particle shape if it has more than one frame of animation
+	tfxEmitterPropertyFlags_animate = 1 << 12,                          //Animate the particle shape if it has more than one frame of animation
 	tfxEmitterPropertyFlags_reverse_animation = 1 << 13,                //Make the image animation go in reverse
 	tfxEmitterPropertyFlags_play_once = 1 << 14,                        //Play the animation once only
-	tfxEmitterPropertyFlags_random_start_frame = 1 << 15,                //Start the animation of the image from a random frame
-	tfxEmitterPropertyFlags_wrap_single_sprite = 1 << 16,                //When recording sprite data, single particles can have their invalid capured index set to the current frame for better looping
-	tfxEmitterPropertyFlags_is_in_folder = 1 << 17,                        //This effect is located inside a folder. Todo: move this to effect properties
-	tfxEmitterPropertyFlags_use_spawn_ratio = 1 << 18,                    //Option for area emitters to multiply the amount spawned by a ration of particles per pixels squared
-	tfxEmitterPropertyFlags_effect_is_3d = 1 << 19,                        //Makes the effect run in 3d mode for 3d effects todo: does this need to be here, the effect dictates this?
+	tfxEmitterPropertyFlags_random_start_frame = 1 << 15,               //Start the animation of the image from a random frame
+	tfxEmitterPropertyFlags_wrap_single_sprite = 1 << 16,               //When recording sprite data, single particles can have their invalid capured index set to the current frame for better looping
+	tfxEmitterPropertyFlags_is_in_folder = 1 << 17,                     //This effect is located inside a folder. Todo: move this to effect properties
+	tfxEmitterPropertyFlags_use_spawn_ratio = 1 << 18,                  //Option for area emitters to multiply the amount spawned by a ration of particles per pixels squared
+	tfxEmitterPropertyFlags_effect_is_3d = 1 << 19,                     //Makes the effect run in 3d mode for 3d effects todo: does this need to be here, the effect dictates this?
 	tfxEmitterPropertyFlags_grid_spawn_random = 1 << 20,                //Spawn on grid points but randomly rather then in sequence
-	tfxEmitterPropertyFlags_area_open_ends = 1 << 21,                    //Only sides of the area/cylinder are spawned on when fill area is not checked
-	tfxEmitterPropertyFlags_exclude_from_hue_adjustments = 1 << 22,        //Emitter will be excluded from effect hue adjustments if this flag is checked
-	tfxEmitterPropertyFlags_enabled = 1 << 23,                            //The emitter is enabled or not, meaning it will or will not be added the particle manager with AddEffect
-	tfxEmitterPropertyFlags_match_amount_to_grid_points = 1 << 24,        //Match the amount to spawn with a single emitter to the number of grid points in the effect
-	tfxEmitterPropertyFlags_use_path_for_direction = 1 << 25,            //Make the particles use a path to dictate their direction of travel
-	tfxEmitterPropertyFlags_alt_velocity_lifetime_sampling = 1 << 26,    //The point on the path dictates where on the velocity overtime graph that the particle should sample from rather then the age of the particle
-	tfxEmitterPropertyFlags_alt_color_lifetime_sampling = 1 << 27,        //The point on the path dictates where on the color overtime graph that the particle should sample from rather then the age of the particle
-	tfxEmitterPropertyFlags_alt_size_lifetime_sampling = 1 << 28,        //The point on the path dictates where on the size overtime graph that the particle should sample from rather then the age of the particle
-	tfxEmitterPropertyFlags_use_simple_motion_randomness = 1 << 29,        //Use a simplified way to generate random particle movement which is much less computationally intensive than simplex noise
+	tfxEmitterPropertyFlags_area_open_ends = 1 << 21,                   //Only sides of the area/cylinder are spawned on when fill area is not checked
+	tfxEmitterPropertyFlags_exclude_from_hue_adjustments = 1 << 22,     //Emitter will be excluded from effect hue adjustments if this flag is checked
+	tfxEmitterPropertyFlags_enabled = 1 << 23,                          //The emitter is enabled or not, meaning it will or will not be added the particle manager with AddEffect
+	tfxEmitterPropertyFlags_match_amount_to_grid_points = 1 << 24,      //Match the amount to spawn with a single emitter to the number of grid points in the effect
+	tfxEmitterPropertyFlags_use_path_for_direction = 1 << 25,           //Make the particles use a path to dictate their direction of travel
+	tfxEmitterPropertyFlags_alt_velocity_lifetime_sampling = 1 << 26,	//The point on the path dictates where on the velocity overtime graph that the particle should sample from rather then the age of the particle
+	tfxEmitterPropertyFlags_alt_color_lifetime_sampling = 1 << 27,      //The point on the path dictates where on the color overtime graph that the particle should sample from rather then the age of the particle
+	tfxEmitterPropertyFlags_alt_size_lifetime_sampling = 1 << 28,       //The point on the path dictates where on the size overtime graph that the particle should sample from rather then the age of the particle
+	tfxEmitterPropertyFlags_use_simple_motion_randomness = 1 << 29,     //Use a simplified way to generate random particle movement which is much less computationally intensive than simplex noise
 	tfxEmitterPropertyFlags_spawn_location_source = 1 << 30,            //This emitter is the source for another emitter that uses it to spawn particles at the location of this emitters' particles
-	tfxEmitterPropertyFlags_use_color_hint = 1 << 31                    //Activate a second color to tint the particles and mix between the two colors.
+	tfxEmitterPropertyFlags_use_color_hint = 1 << 31	                //Activate a second color to tint the particles and mix between the two colors.
+};
+
+enum tfx_color_ramp_flag_bits {
+	tfxColorRampFlags_none = 0,
+	tfxColorRampFlags_use_sinusoidal_ramp_generation = 1 << 0,			//Use this flag to toggle between sinusoidal color ramp generation
 };
 
 enum tfx_particle_flag_bits : unsigned int {
 	tfxParticleFlags_none = 0,
 	tfxParticleFlags_fresh = 1 << 0,                                    //Particle has just spawned this frame    
-	tfxParticleFlags_remove = 1 << 4,                                    //Particle will be removed this or next frame
-	tfxParticleFlags_has_velocity = 1 << 5,                                //Flagged if the particle is currently moving
-	tfxParticleFlags_has_sub_effects = 1 << 6,                            //Flagged if the particle has sub effects
-	tfxParticleFlags_capture_after_transform = 1 << 15,                    //Particle will be captured after a transfrom, used for traversing lines and looping back to the beginning to avoid lerping imbetween
+	tfxParticleFlags_remove = 1 << 4,                                   //Particle will be removed this or next frame
+	tfxParticleFlags_has_velocity = 1 << 5,                             //Flagged if the particle is currently moving
+	tfxParticleFlags_has_sub_effects = 1 << 6,                          //Flagged if the particle has sub effects
+	tfxParticleFlags_capture_after_transform = 1 << 15,                 //Particle will be captured after a transfrom, used for traversing lines and looping back to the beginning to avoid lerping imbetween
 };
 
 enum tfx_emitter_state_flag_bits : unsigned int {
 	tfxEmitterStateFlags_none = 0,
 	tfxEmitterStateFlags_random_color = 1 << 0,
 	tfxEmitterStateFlags_relative_position = 1 << 1,                    //Keep the particles position relative to the current position of the emitter
-	tfxEmitterStateFlags_relative_angle = 1 << 2,                        //Keep the angle of the particles relative to the current angle of the emitter
+	tfxEmitterStateFlags_relative_angle = 1 << 2,                       //Keep the angle of the particles relative to the current angle of the emitter
 	tfxEmitterStateFlags_stop_spawning = 1 << 3,                        //Tells the emitter to stop spawning
-	tfxEmitterStateFlags_remove = 1 << 4,                                //Tells the effect/emitter to remove itself from the particle manager immediately
-	tfxEmitterStateFlags_unused1 = 1 << 5,                                //the emitter is enabled. **moved to property state_flags**
+	tfxEmitterStateFlags_remove = 1 << 4,                               //Tells the effect/emitter to remove itself from the particle manager immediately
+	tfxEmitterStateFlags_unused1 = 1 << 5,                              //the emitter is enabled. **moved to property state_flags**
 	tfxEmitterStateFlags_retain_matrix = 1 << 6,                        //Internal flag about matrix usage
-	tfxEmitterStateFlags_no_tween_this_update = 1 << 7,                    //Internal flag generally, but you could use it if you want to teleport the effect to another location
+	tfxEmitterStateFlags_no_tween_this_update = 1 << 7,                 //Internal flag generally, but you could use it if you want to teleport the effect to another location
 	tfxEmitterStateFlags_is_single = 1 << 8,
 	tfxEmitterStateFlags_not_line = 1 << 9,
 	tfxEmitterStateFlags_base_uniform_size = 1 << 10,
-	tfxEmitterStateFlags_lifetime_uniform_size = 1 << 11,                //Keep the size over lifetime of the particle uniform
+	tfxEmitterStateFlags_lifetime_uniform_size = 1 << 11,               //Keep the size over lifetime of the particle uniform
 	tfxEmitterStateFlags_can_spin = 1 << 12,
 	tfxEmitterStateFlags_is_edge_traversal = 1 << 13,
-	tfxEmitterStateFlags_play_once = 1 << 14,                            //Play the animation once only
+	tfxEmitterStateFlags_play_once = 1 << 14,                           //Play the animation once only
 	tfxEmitterStateFlags_loop = 1 << 15,
 	tfxEmitterStateFlags_kill = 1 << 16,
 	tfxEmitterStateFlags_single_shot_done = 1 << 17,
@@ -2615,9 +2621,9 @@ enum tfx_emitter_state_flag_bits : unsigned int {
 	tfxEmitterStateFlags_align_with_velocity = 1 << 21,
 	tfxEmitterStateFlags_is_sub_emitter = 1 << 22,
 	tfxEmitterStateFlags_unused2 = 1 << 23,
-	tfxEmitterStateFlags_can_spin_pitch_and_yaw = 1 << 24,            //For 3d emitters that have free alignment and not always facing the camera
+	tfxEmitterStateFlags_can_spin_pitch_and_yaw = 1 << 24,              //For 3d emitters that have free alignment and not always facing the camera
 	tfxEmitterStateFlags_has_path = 1 << 25,
-	tfxEmitterStateFlags_is_bottom_emitter = 1 << 26,                //This emitter has no child effects, so can spawn particles that could be used in a compute shader if it's enabled
+	tfxEmitterStateFlags_is_bottom_emitter = 1 << 26,                   //This emitter has no child effects, so can spawn particles that could be used in a compute shader if it's enabled
 	tfxEmitterStateFlags_has_rotated_path = 1 << 27,
 	tfxEmitterStateFlags_max_active_paths_reached = 1 << 28,
 	tfxEmitterStateFlags_is_in_ordered_effect = 1 << 29,
@@ -4988,6 +4994,12 @@ struct tfx_graph_lookup_t {
 };
 
 struct tfx_color_ramp_t {
+	//These vectors are for sinusoidal color ramp generation
+	tfx_vec3_t brightness;
+	tfx_vec3_t contrast;
+	tfx_vec3_t frequency;
+	tfx_vec3_t offsets;
+	tfxColorRampFlags flags;
 	tfx_rgba8_t colors[tfxCOLOR_RAMP_WIDTH];
 };
 

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -8045,7 +8045,7 @@ tfxAPI bool GetNextBillboardBuffer(tfx_particle_manager_t *pm, tfx_billboard_ins
 /*After calling GetNextBillboard/SpriteBuffer in a while loop you can call this to reset the index for the next frame
 * @param pm						A pointer to a tfx_particle_manager_t
 */
-tfxAPI bool ResetInstanceBufferLoopIndex(tfx_particle_manager_t *pm);
+tfxAPI void ResetInstanceBufferLoopIndex(tfx_particle_manager_t *pm);
 
 /*
 Set the rotation of a 2d effect

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -6730,21 +6730,25 @@ inline void ClearWrapBit(T* instance, tfx_sprite_data_t *sprite_data) {
 }
 
 template<typename T>
-inline void SpriteDataOffsetCapturedIndexes(T* instance, tfx_sprite_data_t *sprite_data, tfxU32 current_frame, tfxU32 real_frames) {
+inline void SpriteDataOffsetCapturedIndexes(T* instance, tfx_sprite_data_t *sprite_data, tfxU32 previous_frame, tfxU32 current_frame) {
+	tfxU32 layer_offset = 0;
 	for (tfxEachLayer) {
 		for (int j = SpriteDataIndexOffset(sprite_data, current_frame, layer); j != SpriteDataEndIndex(sprite_data, current_frame, layer); ++j) {
 			if (instance[j].captured_index == tfxINVALID) continue;
-			int frame = current_frame - 1;
-			frame = frame < 0 ? real_frames - 1 : frame;
 			tfxU32 wrap_bit = instance[j].captured_index & 0x80000000;
-			instance[j].captured_index = (instance[j].captured_index & 0x0FFFFFFF) + sprite_data->normal.frame_meta[frame].captured_offset + sprite_data->normal.frame_meta[frame].cumulative_offset[layer];
-			tfxPrint("%i) %u, %u, %u, %u, %u, %u", j, instance[j].captured_index, sprite_data->real_time_sprites.uid[instance[j].captured_index].uid, sprite_data->real_time_sprites.uid[instance[j].captured_index].age, sprite_data->real_time_sprites.uid[j].uid, sprite_data->real_time_sprites.uid[j].age, sprite_data->normal.frame_meta[frame].captured_offset);
-			TFX_ASSERT(sprite_data->real_time_sprites.uid[instance[j].captured_index].uid == sprite_data->real_time_sprites.uid[j].uid);
+			instance[j].captured_index = (instance[j].captured_index & 0x0FFFFFFF) + sprite_data->normal.frame_meta[previous_frame].index_offset[layer];
+			if (sprite_data->real_time_sprites.uid[instance[j].captured_index].uid != sprite_data->real_time_sprites.uid[j].uid) {
+				//tfxPrint("%i) %u, %u, %u, %u, %u, %u", j, instance[j].captured_index, sprite_data->real_time_sprites.uid[instance[j].captured_index].uid, sprite_data->real_time_sprites.uid[instance[j].captured_index].age, sprite_data->real_time_sprites.uid[j].uid, sprite_data->real_time_sprites.uid[j].age, sprite_data->normal.frame_meta[previous_frame].captured_offset);
+			}
+			//TFX_ASSERT(sprite_data->real_time_sprites.uid[instance[j].captured_index].uid == sprite_data->real_time_sprites.uid[j].uid);
 			instance[j].captured_index |= wrap_bit;
 		}
-		tfxPrint("---------------------");
+		if (layer > 0) {
+			layer_offset += sprite_data->normal.frame_meta[previous_frame].cumulative_offset[layer];
+		}
+		//tfxPrint("--------- %i - %i ------------", current_frame, layer);
 	}
-	tfxPrint("*****************************");
+	//tfxPrint("************* end of frame %i ****************", current_frame);
 }
 
 template<typename T>

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -6716,7 +6716,8 @@ tfxAPI_EDITOR void UpdateEmitterControlProfile(tfx_effect_emitter_t *emitter);
 
 tfxAPI_EDITOR void CompletePMWork(tfx_particle_manager_t *pm);
 
-tfxINTERNAL tfxU32 SpawnParticles2d(tfx_particle_manager_t *pm, tfx_spawn_work_entry_t *spawn_work_entry, tfxU32 max_spawn_count);
+tfxINTERNAL tfxU32 SpawnParticles(tfx_particle_manager_t *pm, tfx_spawn_work_entry_t *work_entry);
+
 tfxINTERNAL void SpawnParticlePoint2d(tfx_work_queue_t *queue, void *data);
 tfxINTERNAL void SpawnParticleLine2d(tfx_work_queue_t *queue, void *data);
 tfxINTERNAL void SpawnParticleArea2d(tfx_work_queue_t *queue, void *data);
@@ -6737,7 +6738,6 @@ tfxINTERNAL void SpawnParticleSpin2d(tfx_work_queue_t *queue, void *data);
 tfxINTERNAL void DoSpawnWork3d(tfx_work_queue_t *queue, void *data);
 tfxINTERNAL void DoSpawnWork2d(tfx_work_queue_t *queue, void *data);
 
-tfxINTERNAL tfxU32 SpawnParticles3d(tfx_work_queue_t *queue, void *data);
 tfxINTERNAL void SpawnParticlePoint3d(tfx_work_queue_t *queue, void *data);
 tfxINTERNAL void SpawnParticleOtherEmitter2d(tfx_work_queue_t *queue, void *data);
 tfxINTERNAL void SpawnParticleOtherEmitter3d(tfx_work_queue_t *queue, void *data);

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -5669,7 +5669,7 @@ struct tfx_sprite_soa_t {                       //3d takes 56 bytes of bandwidth
 	tfxU32 *intensity_life;                     //The multiplier for the sprite color and the lifetime of the particle (0..1)
 	float *stretch;                             //Multiplier for how much the particle is stretched in the shader
 	tfxU32 *alignment;                          //The alignment of the particle. 2 16bit floats for 2d and 3 8bit floats for 3d
-	float *sharpness;							//Alpha sharpness for the texture dissolve/alpha calculations
+	tfxU32 *curved_alpha;						//Alpha sharpness for the texture dissolve/alpha calculations
 	tfxU32 *indexes;							//The indexes to lookup the color in the color ramp textures and the image texture data
 };
 

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -2192,8 +2192,8 @@ enum tfx_graph_type : unsigned char {
 	tfxOvertime_direction_turbulance,
 	tfxOvertime_velocity_adjuster,
 	tfxOvertime_intensity,
-	tfxOvertime_hint_intensity,
-	tfxOvertime_color_mix_balance,
+	tfxOvertime_alpha_sharpness,
+	tfxOvertime_curved_alpha,
 	tfxOvertime_direction,
 	tfxOvertime_noise_resolution,
 	tfxOvertime_motion_randomness,
@@ -5063,8 +5063,8 @@ struct tfx_overtime_attributes_t {
 	tfx_graph_t direction_turbulance;
 	tfx_graph_t velocity_adjuster;
 	tfx_graph_t intensity;
-	tfx_graph_t hint_intensity;
-	tfx_graph_t color_mix_balance;
+	tfx_graph_t alpha_sharpness;
+	tfx_graph_t curved_alpha;
 	tfx_graph_t direction;
 	tfx_graph_t noise_resolution;
 	tfx_graph_t motion_randomness;

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -1070,7 +1070,11 @@ void tfxAddHostMemoryPool(size_t size);
 void *tfxAllocate(size_t size);
 void *tfxReallocate(void *memory, size_t size);
 void *tfxAllocateAligned(size_t size, size_t alignment);
+//Do a safe copy where checks are made to ensure that the boundaries of the memory block being copied to are respected
+//This assumes that dst is the start address of the block. If you're copying to a range that is offset from the beginning
+//of the block then you can use tfx_SafeCopyBlock instead.
 tfx_bool tfx_SafeCopy(void *dst, void *src, tfx_size size);
+tfx_bool tfx_SafeCopyBlock(void *dst_block_start, void *dst, void *src, tfx_size size);
 tfx_bool tfx_SafeMemset(void *allocation, void *dst, int value, tfx_size size);
 tfx_allocator *tfxGetAllocator();
 

--- a/timelinefx.h
+++ b/timelinefx.h
@@ -5660,16 +5660,17 @@ struct tfx_frame_meta_t {
 //InitSprite3dSoA is called to initialise 3d sprites and InitSprite2dArray for 2d sprites. This is all managed internally by the particle manager. It's convenient to have both 2d and
 //3d in one struct like this as it makes it a lot easier to use the same control functions where we can. Also note that stretch and alignment for 3d sprites are packed into
 //stretch_alignment_x and alignment_yz as 16bit floats. 2d uses the float for stretch and packs xy alignment into alignment_yz
-struct tfx_sprite_soa_t {                        //3d takes 56 bytes of bandwidth, 2d takes 40 bytes of bandwidth
-	tfxU32 *property_indexes;                    //The image frame of animation index packed with alignment option flag and property_index
-	tfxU32 *captured_index;                        //The index of the sprite in the previous frame so that it can be looked up and interpolated with
+struct tfx_sprite_soa_t {                       //3d takes 56 bytes of bandwidth, 2d takes 40 bytes of bandwidth
+	tfxU32 *property_indexes;                   //The image frame of animation index packed with alignment option flag and property_index
+	tfxU32 *captured_index;                     //The index of the sprite in the previous frame so that it can be looked up and interpolated with
 	tfx_unique_sprite_id_t *uid;                //Unique particle id of the sprite, only used when recording sprite data
-	tfx_sprite_transform3d_t *transform_3d;        //Transform data for 3d sprites
-	tfx_sprite_transform2d_t *transform_2d;        //Transform data for 2d sprites
-	tfx_rgba8_t *color;                            //The color tint of the sprite and blend factor in alpha channel
-	float *intensity;                            //The multiplier for the sprite color
-	float *stretch;                                //Multiplier for how much the particle is stretched in the shader
-	tfxU32 *alignment;                            //The alignment of the particle. 2 16bit floats for 2d and 3 8bit floats for 3d
+	tfx_sprite_transform3d_t *transform_3d;     //Transform data for 3d sprites
+	tfx_sprite_transform2d_t *transform_2d;     //Transform data for 2d sprites
+	tfx_rgba8_t *color;                         //The color tint of the sprite and blend factor in alpha channel
+	float *intensity;                           //The multiplier for the sprite color
+	float *stretch;                             //Multiplier for how much the particle is stretched in the shader
+	tfxU32 *alignment;                          //The alignment of the particle. 2 16bit floats for 2d and 3 8bit floats for 3d
+	tfxU32 *lerp_values;						//The particle lifetime and color mix balance packed into 16bit snorm floats
 };
 
 enum tfxSpriteBufferMode {
@@ -5718,6 +5719,7 @@ struct tfx_sprite_data_soa_t {    //64 bytes or 60 after uid is removed as it's 
 	float *intensity;
 	float *stretch;
 	tfxU32 *alignment;            //normalised alignment vector 3 floats packed into 10bits each with 2 bits left over
+	tfxU32 *lerp_values;		 
 };
 
 struct tfx_wide_lerp_transform_result_t {
@@ -6477,6 +6479,7 @@ tfxAPI_EDITOR tfx_vec2_t UnPack16bit(tfxU32 in);
 tfxINTERNAL tfx_vec2_t UnPack16bitUnsigned(tfxU32 in);
 tfxINTERNAL tfxWideInt PackWide16bitStretch(tfxWideFloat &v_x, tfxWideFloat &v_y);
 tfxAPI_EDITOR tfxWideInt PackWide16bit(tfxWideFloat &v_x, tfxWideFloat &v_y);
+tfxAPI_EDITOR tfxWideInt PackWide16bitUNorm(tfxWideFloat &v_x, tfxWideFloat &v_y);
 tfxAPI_EDITOR void UnPackWide16bit(tfxWideInt in, tfxWideFloat &x, tfxWideFloat &y);
 tfxAPI tfxWideInt PackWide8bitXYZ(tfxWideFloat const &v_x, tfxWideFloat const &v_y, tfxWideFloat const &v_z);
 tfxINTERNAL tfxWideInt PackWide10bit(tfxWideFloat const &v_x, tfxWideFloat const &v_y, tfxWideFloat const &v_z);


### PR DESCRIPTION
This version has revamped how the particle manager produces all the sprites to be drawn on the gpu. It now creates an instance buffer that can be copied in full to the GPU after each update of the particle manager. All interpolation from the previous frame can now just happen in the vertex shader with no extra work needed from the CPU. This is much more efficient overall.

Also added alpha sharpness and curved alpha graphs for more nuanced particle fading/dissolving effects.